### PR TITLE
feat: Nacelle Reference page and table

### DIFF
--- a/__mocks__/contentTypes.ts
+++ b/__mocks__/contentTypes.ts
@@ -1,0 +1,102 @@
+const contentTypes = {
+  sys: {
+    type: 'Array'
+  },
+  total: 11,
+  skip: 0,
+  limit: 100,
+  items: [
+    {
+      sys: {
+        space: {
+          sys: {
+            type: 'Link',
+            linkType: 'Space',
+            id: 'iojm91u4ez5c'
+          }
+        },
+        id: 'collectionGrid',
+        type: 'ContentType',
+        createdAt: '2020-07-16T20:07:48.743Z',
+        updatedAt: '2023-03-15T14:03:55.077Z',
+        environment: {
+          sys: {
+            id: 'staging',
+            type: 'Link',
+            linkType: 'Environment'
+          }
+        },
+        publishedVersion: 91,
+        publishedAt: '2023-03-14T17:49:36.378Z',
+        firstPublishedAt: '2020-07-16T20:07:49.223Z',
+        createdBy: {
+          sys: {
+            type: 'Link',
+            linkType: 'User',
+            id: '2M499e6hafXfray3Snb66l'
+          }
+        },
+        updatedBy: {
+          sys: {
+            type: 'Link',
+            linkType: 'User',
+            id: '0LxN7Nzo5ASE6wuZSYoP5b'
+          }
+        },
+        publishedCounter: 46,
+        version: 100,
+        publishedBy: {
+          sys: {
+            type: 'Link',
+            linkType: 'User',
+            id: '0LxN7Nzo5ASE6wuZSYoP5b'
+          }
+        }
+      },
+      displayField: 'title',
+      name: 'Collection Grid',
+      description: 'Shows a grid of products from a specific collection',
+      fields: [
+        {
+          id: 'product',
+          name: 'Product',
+          type: 'JSON',
+          localized: false,
+          required: false,
+          validations: [],
+          disabled: false,
+          omitted: false
+        },
+        {
+          id: 'nclRefMap',
+          name: 'Nacelle References',
+          type: 'Symbol',
+          localized: false,
+          required: false,
+          validations: [{ linkContentType: ['product:PRODUCT'] }],
+          disabled: true,
+          omitted: false
+        },
+        {
+          id: 'collectionHandle',
+          name: 'Collection Handle',
+          type: 'Symbol',
+          localized: false,
+          required: false,
+          validations: [
+            {
+              regexp: {
+                pattern: 'PRODUCT | COLLECTION',
+                flags: ''
+              }
+            }
+          ],
+          disabled: false,
+          omitted: false
+        }
+      ]
+    }
+  ]
+}
+
+export default contentTypes

--- a/__mocks__/editorInterfaces.ts
+++ b/__mocks__/editorInterfaces.ts
@@ -1,0 +1,16 @@
+const editorInterfaces = {
+  controls: [
+    {
+      fieldId: 'collectionHandle',
+      widgetId: 'appId',
+      widgetNamespace: 'app'
+    },
+    {
+      fieldId: 'product',
+      widgetId: 'appId',
+      widgetNamespace: 'app'
+    }
+  ]
+}
+
+export default editorInterfaces

--- a/__mocks__/sdk.ts
+++ b/__mocks__/sdk.ts
@@ -6,6 +6,34 @@ const sdk = {
     space: 'xxx',
     environment: 'xxx',
     app: 'appId'
+  },
+  contentType: {
+    sys: {
+      id: 'contentType'
+    }
+  },
+  window: {
+    updateHeight: jest.fn(),
+    startAutoResizer: jest.fn()
+  },
+  app: {
+    getCurrentState: jest.fn(),
+    setReady: jest.fn(),
+    onConfigure: jest.fn(),
+    getParameters: jest.fn()
+  },
+  field: {
+    getValue: jest.fn()
+  },
+  parameters: {
+    invocation: {
+      value: 'value from invocation'
+    },
+    installation: {
+      nacelleSpaceId: 'spaceId',
+      nacelleSpaceToken: 'spaceToken',
+      nacelleEndpoint: 'endpoint'
+    }
   }
 }
 

--- a/__mocks__/sdk.ts
+++ b/__mocks__/sdk.ts
@@ -1,0 +1,12 @@
+const sdk = {
+  cmaAdapter: {
+    makeRequest: jest.fn()
+  },
+  ids: {
+    space: 'xxx',
+    environment: 'xxx',
+    app: 'appId'
+  }
+}
+
+export default sdk

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,10 @@
         "react-dom": "^16.13.1",
         "react-scripts": "4.0.1",
         "typescript": "^3.9.7"
+      },
+      "engines": {
+        "node": ">=16.11 <17",
+        "npm": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,8 @@
         "@types/node": "^12.12.53",
         "@types/react": "^16.9.43",
         "@types/react-dom": "^16.9.8",
-        "contentful": "^10.2.0",
         "contentful-management": "^10.35.3",
-        "contentful-ui-extensions-sdk": "^4.3.1",
+        "contentful-ui-extensions-sdk": "^4.17.2",
         "localforage": "^1.9.0",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
@@ -3760,6 +3759,63 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+    },
     "node_modules/@nacelle/client-js-sdk": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@nacelle/client-js-sdk/-/client-js-sdk-1.0.5.tgz",
@@ -4315,9 +4371,9 @@
       }
     },
     "node_modules/@svgr/webpack/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -5384,12 +5440,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "node_modules/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
@@ -5452,9 +5508,9 @@
       }
     },
     "node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -5574,7 +5630,7 @@
     "node_modules/ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "integrity": "sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA==",
       "engines": [
         "node >= 0.8.0"
       ],
@@ -5583,9 +5639,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
@@ -5820,9 +5876,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -6409,29 +6465,32 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "node_modules/body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dependencies": {
-        "bytes": "3.1.1",
+        "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
-        "type-is": "~1.6.18"
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/body-parser/node_modules/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -6442,6 +6501,14 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/bonjour": {
@@ -7350,27 +7417,11 @@
       ]
     },
     "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/contentful": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.2.0.tgz",
-      "integrity": "sha512-jygmcO4u/1gVzobgoQCja7mBV+4JZyeNOvoZ8Yv13g/7w6nY+NoMUPTuE0YK/CJLVTYI7sW4HMuuFParI/etOQ==",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^0.26.1",
-        "contentful-resolve-response": "^1.3.6",
-        "contentful-sdk-core": "^7.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "type-fest": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/contentful-management": {
@@ -7458,22 +7509,6 @@
         "node": ">=12.20"
       }
     },
-    "node_modules/contentful-resolve-response": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.7.0.tgz",
-      "integrity": "sha512-NIaQkXAdNWf/1wp13aqtrmHWHy71oCIIbynojGs9ONDtA7hBXC2yCEf2IjzfgOkrkEfOMvwDQHizD0WmL6FR8w==",
-      "dependencies": {
-        "fast-copy": "^2.1.7"
-      },
-      "engines": {
-        "node": ">=4.7.2"
-      }
-    },
-    "node_modules/contentful-resolve-response/node_modules/fast-copy": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
-    },
     "node_modules/contentful-sdk-core": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
@@ -7495,65 +7530,11 @@
       "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/contentful-ui-extensions-sdk": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-4.3.1.tgz",
-      "integrity": "sha512-ht8vPXBaBcGqzxvn+Di3hGWEcfkbBSzhfvkw9QLqVuKq9oPariLAgIwC75dfsmsfF9Ctljiy2sop6l5I2nFdDw==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-4.17.2.tgz",
+      "integrity": "sha512-rZ2Z7Fjabqi3Hp6UecGYVQG0YSOB/XaNCcv0iljVe85k1ZvJuUMrxm9Jdpqf3IpVDPHFnQIh7pJnLU4a37wGwQ==",
       "peerDependencies": {
-        "contentful-management": "^7.30.0"
-      }
-    },
-    "node_modules/contentful/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
-    "node_modules/contentful/node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/contentful/node_modules/type-fest": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
-      "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7.0"
-      }
-    },
-    "node_modules/contentful/node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=12.20"
+        "contentful-management": ">=7.30.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -7565,9 +7546,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -7906,9 +7887,9 @@
       }
     },
     "node_modules/css-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -8268,9 +8249,9 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "engines": {
         "node": ">=0.10"
       }
@@ -8548,9 +8529,13 @@
       }
     },
     "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -8821,7 +8806,7 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/ejs": {
       "version": "2.7.4",
@@ -8892,7 +8877,7 @@
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9967,7 +9952,7 @@
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9986,12 +9971,9 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-      "dependencies": {
-        "original": "^1.0.0"
-      },
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
+      "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -10182,37 +10164,38 @@
       }
     },
     "node_modules/express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dependencies": {
-        "accepts": "~1.3.7",
+        "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.1",
+        "cookie": "0.5.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.2.0",
         "fresh": "0.5.2",
+        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
         "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -10234,6 +10217,14 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/express/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10252,6 +10243,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/express/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/ext": {
       "version": "1.6.0",
@@ -10424,9 +10423,9 @@
       }
     },
     "node_modules/file-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -10479,16 +10478,16 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -10501,6 +10500,14 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/find-cache-dir": {
@@ -10831,7 +10838,7 @@
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -11451,18 +11458,34 @@
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dependencies": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-proxy": {
@@ -13419,23 +13442,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
     "node_modules/json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
       "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -13548,9 +13563,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -13561,9 +13576,9 @@
       }
     },
     "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -13597,9 +13612,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -13773,7 +13788,7 @@
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -13949,9 +13964,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/minipass": {
       "version": "3.1.6",
@@ -14155,9 +14173,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "node_modules/negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -14584,9 +14602,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -14684,14 +14702,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "dependencies": {
-        "url-parse": "^1.4.3"
       }
     },
     "node_modules/os-browserify": {
@@ -16455,9 +16465,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
       },
@@ -16552,12 +16565,12 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "dependencies": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
@@ -16566,9 +16579,9 @@
       }
     },
     "node_modules/raw-body/node_modules/bytes": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -17449,16 +17462,16 @@
       "deprecated": "https://github.com/lydell/resolve-url#deprecated"
     },
     "node_modules/resolve-url-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.4.tgz",
-      "integrity": "sha512-D3sQ04o0eeQEySLrcz4DsX3saHfsr8/N6tfhblxgZKXxMT2Louargg12oGNfoTRLV09GXhVUe5/qgA5vdgNigg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.5.tgz",
+      "integrity": "sha512-mgFMCmrV/tA4738EsFmPFE5/MaqSgUMe8LK971kVEKA/RrNVb7+VqFsg/qmKyythf34eyq476qIobP/gfFBGSQ==",
       "dependencies": {
         "adjust-sourcemap-loader": "3.0.0",
         "camelcase": "5.3.1",
         "compose-function": "3.0.3",
         "convert-source-map": "1.7.0",
         "es6-iterator": "2.0.3",
-        "loader-utils": "1.2.3",
+        "loader-utils": "^1.2.3",
         "postcss": "7.0.36",
         "rework": "1.0.1",
         "rework-visit": "1.0.0",
@@ -17474,38 +17487,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/resolve-url-loader/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve-url-loader/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/resolve-url-loader/node_modules/loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/resolve-url-loader/node_modules/source-map": {
@@ -18119,23 +18100,23 @@
       }
     },
     "node_modules/send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "dependencies": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -18152,12 +18133,28 @@
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/send/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "5.0.1",
@@ -18217,14 +18214,14 @@
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "node_modules/serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "dependencies": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -19110,14 +19107,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -19196,9 +19185,9 @@
       }
     },
     "node_modules/style-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -19529,9 +19518,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "dependencies": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -19574,8 +19563,6 @@
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
       "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -19738,12 +19725,13 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+      "version": "5.17.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
+      "integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "bin": {
@@ -19751,22 +19739,6 @@
       },
       "engines": {
         "node": ">=10"
-      },
-      "peerDependencies": {
-        "acorn": "^8.5.0"
-      },
-      "peerDependenciesMeta": {
-        "acorn": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/terser/node_modules/commander": {
@@ -19975,9 +19947,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -20197,7 +20169,7 @@
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -20310,9 +20282,9 @@
       }
     },
     "node_modules/url-loader/node_modules/loader-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-      "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -20340,9 +20312,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -20668,7 +20640,7 @@
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "optional": true,
       "dependencies": {
         "is-glob": "^3.1.0",
@@ -21049,9 +21021,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/cliui/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
@@ -21147,7 +21119,7 @@
     "node_modules/webpack-dev-server/node_modules/glob-parent": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
       "dependencies": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -21323,9 +21295,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
@@ -21389,9 +21361,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
@@ -25013,6 +24985,56 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      },
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+        }
+      }
+    },
     "@nacelle/client-js-sdk": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@nacelle/client-js-sdk/-/client-js-sdk-1.0.5.tgz",
@@ -25364,9 +25386,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -26251,12 +26273,12 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
     },
     "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       }
     },
     "acorn": {
@@ -26299,9 +26321,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -26391,12 +26413,12 @@
     "ansi-html": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
-      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4="
+      "integrity": "sha512-JoAxEa1DfP9m2xfB/y2r/aKcwXNlltr4+0QSBC4TrLfcxyvepX2Pv0t/xpgGV5bGsDzCYV8SzjWgyCW0T9yYbA=="
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "4.2.1",
@@ -26578,9 +26600,9 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "requires": {
         "lodash": "^4.17.14"
       }
@@ -27051,26 +27073,28 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
     },
     "body-parser": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "requires": {
-        "bytes": "3.1.1",
+        "bytes": "3.1.2",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.8.1",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.9.6",
-        "raw-body": "2.4.2",
-        "type-is": "~1.6.18"
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         },
         "debug": {
           "version": "2.6.9",
@@ -27079,6 +27103,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         }
       }
     },
@@ -27813,49 +27842,9 @@
       }
     },
     "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "contentful": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.2.0.tgz",
-      "integrity": "sha512-jygmcO4u/1gVzobgoQCja7mBV+4JZyeNOvoZ8Yv13g/7w6nY+NoMUPTuE0YK/CJLVTYI7sW4HMuuFParI/etOQ==",
-      "requires": {
-        "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^0.26.1",
-        "contentful-resolve-response": "^1.3.6",
-        "contentful-sdk-core": "^7.0.2",
-        "json-stringify-safe": "^5.0.1",
-        "type-fest": "^3.1.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.15.2",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-        },
-        "type-fest": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
-          "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
-          "requires": {}
-        },
-        "typescript": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-          "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-          "peer": true
-        }
-      }
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
     },
     "contentful-management": {
       "version": "10.35.3",
@@ -27909,21 +27898,6 @@
         }
       }
     },
-    "contentful-resolve-response": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.7.0.tgz",
-      "integrity": "sha512-NIaQkXAdNWf/1wp13aqtrmHWHy71oCIIbynojGs9ONDtA7hBXC2yCEf2IjzfgOkrkEfOMvwDQHizD0WmL6FR8w==",
-      "requires": {
-        "fast-copy": "^2.1.7"
-      },
-      "dependencies": {
-        "fast-copy": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-          "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
-        }
-      }
-    },
     "contentful-sdk-core": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
@@ -27944,9 +27918,9 @@
       }
     },
     "contentful-ui-extensions-sdk": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-4.3.1.tgz",
-      "integrity": "sha512-ht8vPXBaBcGqzxvn+Di3hGWEcfkbBSzhfvkw9QLqVuKq9oPariLAgIwC75dfsmsfF9Ctljiy2sop6l5I2nFdDw==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/contentful-ui-extensions-sdk/-/contentful-ui-extensions-sdk-4.17.2.tgz",
+      "integrity": "sha512-rZ2Z7Fjabqi3Hp6UecGYVQG0YSOB/XaNCcv0iljVe85k1ZvJuUMrxm9Jdpqf3IpVDPHFnQIh7pJnLU4a37wGwQ==",
       "requires": {}
     },
     "convert-source-map": {
@@ -27958,9 +27932,9 @@
       }
     },
     "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -28233,9 +28207,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -28509,9 +28483,9 @@
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
     },
     "dedent": {
       "version": "0.7.0",
@@ -28723,9 +28697,9 @@
       }
     },
     "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -28948,7 +28922,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "ejs": {
       "version": "2.7.4",
@@ -29008,7 +28982,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -29763,7 +29737,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -29776,12 +29750,9 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "eventsource": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
-      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
-      "requires": {
-        "original": "^1.0.0"
-      }
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
+      "integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA=="
     },
     "evp_bytestokey": {
       "version": "1.0.3",
@@ -29933,37 +29904,38 @@
       }
     },
     "express": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
-      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "requires": {
-        "accepts": "~1.3.7",
+        "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.19.1",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.4.1",
+        "cookie": "0.5.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
+        "finalhandler": "1.2.0",
         "fresh": "0.5.2",
+        "http-errors": "2.0.0",
         "merge-descriptors": "1.0.1",
         "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.9.6",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.17.2",
-        "serve-static": "1.14.2",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
         "setprototypeof": "1.2.0",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -29982,10 +29954,20 @@
             "ms": "2.0.0"
           }
         },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         }
       }
     },
@@ -30130,9 +30112,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -30171,16 +30153,16 @@
       }
     },
     "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
+        "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       },
       "dependencies": {
@@ -30191,6 +30173,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         }
       }
     },
@@ -30457,7 +30444,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
     "from2": {
       "version": "2.3.0",
@@ -30922,15 +30909,27 @@
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+        }
       }
     },
     "http-proxy": {
@@ -32390,23 +32389,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
-    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
       "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -32495,9 +32486,9 @@
       "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -32505,9 +32496,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -32537,9 +32528,9 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -32690,7 +32681,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -32821,9 +32812,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "minipass": {
       "version": "3.1.6",
@@ -32990,9 +32981,9 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
     "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -33327,9 +33318,9 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -33399,14 +33390,6 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
-      }
-    },
-    "original": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
-      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
-      "requires": {
-        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -34850,9 +34833,12 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "qs": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "query-string": {
       "version": "4.3.4",
@@ -34914,20 +34900,20 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "raw-body": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
       "requires": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
       "dependencies": {
         "bytes": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-          "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+          "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         }
       }
     },
@@ -35621,16 +35607,16 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "resolve-url-loader": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.4.tgz",
-      "integrity": "sha512-D3sQ04o0eeQEySLrcz4DsX3saHfsr8/N6tfhblxgZKXxMT2Louargg12oGNfoTRLV09GXhVUe5/qgA5vdgNigg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.5.tgz",
+      "integrity": "sha512-mgFMCmrV/tA4738EsFmPFE5/MaqSgUMe8LK971kVEKA/RrNVb7+VqFsg/qmKyythf34eyq476qIobP/gfFBGSQ==",
       "requires": {
         "adjust-sourcemap-loader": "3.0.0",
         "camelcase": "5.3.1",
         "compose-function": "3.0.3",
         "convert-source-map": "1.7.0",
         "es6-iterator": "2.0.3",
-        "loader-utils": "1.2.3",
+        "loader-utils": "^1.2.3",
         "postcss": "7.0.36",
         "rework": "1.0.1",
         "rework-visit": "1.0.0",
@@ -35641,29 +35627,6 @@
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -36153,23 +36116,23 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "send": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.8.1",
+        "http-errors": "2.0.0",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "~2.3.0",
+        "on-finished": "2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
+        "statuses": "2.0.1"
       },
       "dependencies": {
         "debug": {
@@ -36183,14 +36146,24 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
             }
           }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
         },
         "ms": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
         }
       }
     },
@@ -36248,14 +36221,14 @@
       }
     },
     "serve-static": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.17.2"
+        "send": "0.18.0"
       }
     },
     "set-blocking": {
@@ -36980,13 +36953,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
         "ansi-regex": "^5.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        }
       }
     },
     "strip-bom": {
@@ -37036,9 +37002,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -37303,9 +37269,9 @@
       }
     },
     "terser": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-      "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.6.1",
@@ -37343,9 +37309,7 @@
         "acorn": {
           "version": "8.7.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-          "optional": true,
-          "peer": true
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
         },
         "commander": {
           "version": "2.20.3",
@@ -37452,20 +37416,14 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "terser": {
-          "version": "5.10.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-          "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+          "version": "5.17.6",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
+          "integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
           "requires": {
+            "@jridgewell/source-map": "^0.3.2",
+            "acorn": "^8.5.0",
             "commander": "^2.20.0",
-            "source-map": "~0.7.2",
             "source-map-support": "~0.5.20"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-            }
           }
         }
       }
@@ -37624,9 +37582,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -37795,7 +37753,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "unquote": {
       "version": "1.1.1",
@@ -37888,9 +37846,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -37910,9 +37868,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -38178,7 +38136,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "optional": true,
           "requires": {
             "is-glob": "^3.1.0",
@@ -38697,9 +38655,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+              "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -38771,7 +38729,7 @@
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
           "requires": {
             "is-glob": "^3.1.0",
             "path-dirname": "^1.0.0"
@@ -38906,9 +38864,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+              "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
             },
             "strip-ansi": {
               "version": "5.2.0",
@@ -38956,9 +38914,9 @@
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+              "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
             },
             "strip-ansi": {
               "version": "5.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "contentful-app-nacelle",
       "version": "0.2.0",
       "dependencies": {
+        "@contentful/f36-components": "^4.40.0",
         "@contentful/field-editor-single-line": "^0.8.4",
         "@contentful/field-editor-test-utils": "^0.6.4",
         "@contentful/forma-36-fcss": "0.0.35",
@@ -21,6 +22,8 @@
         "@types/node": "^12.12.53",
         "@types/react": "^16.9.43",
         "@types/react-dom": "^16.9.8",
+        "contentful": "^10.2.0",
+        "contentful-management": "^10.35.3",
         "contentful-ui-extensions-sdk": "^4.3.1",
         "localforage": "^1.9.0",
         "react": "^16.13.1",
@@ -1817,11 +1820,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1936,6 +1939,1034 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@contentful/f36-components": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.40.0.tgz",
+      "integrity": "sha512-oEin2WmigFSITuh2MiCMGvOPdAyzJaw4VxTF6UBZjeOtX/ZA0Vf9ByyOgYh1ugVnrYH/wGF3E9Qno33LYWQZCQ==",
+      "dependencies": {
+        "@contentful/f36-accordion": "^4.40.0",
+        "@contentful/f36-asset": "^4.40.0",
+        "@contentful/f36-autocomplete": "^4.40.0",
+        "@contentful/f36-badge": "^4.40.0",
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-card": "^4.40.0",
+        "@contentful/f36-collapse": "^4.40.0",
+        "@contentful/f36-copybutton": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-datepicker": "^4.40.0",
+        "@contentful/f36-datetime": "^4.40.0",
+        "@contentful/f36-drag-handle": "^4.40.0",
+        "@contentful/f36-empty-state": "^4.40.0",
+        "@contentful/f36-entity-list": "^4.40.0",
+        "@contentful/f36-forms": "^4.40.0",
+        "@contentful/f36-icon": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-list": "^4.40.0",
+        "@contentful/f36-menu": "^4.40.0",
+        "@contentful/f36-modal": "^4.40.0",
+        "@contentful/f36-note": "^4.40.0",
+        "@contentful/f36-notification": "^4.40.0",
+        "@contentful/f36-pagination": "^4.40.0",
+        "@contentful/f36-pill": "^4.40.0",
+        "@contentful/f36-popover": "^4.40.0",
+        "@contentful/f36-skeleton": "^4.40.0",
+        "@contentful/f36-spinner": "^4.40.0",
+        "@contentful/f36-table": "^4.40.0",
+        "@contentful/f36-tabs": "^4.40.0",
+        "@contentful/f36-text-link": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.40.0",
+        "@contentful/f36-typography": "^4.40.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "@types/react": "16.14.22",
+        "@types/react-dom": "16.9.14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-accordion": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.40.0.tgz",
+      "integrity": "sha512-csALGciWyL0FId4tpAwSLwpyqyjWI9U/pB2I2HDgA75uyxZWnVBTcKQnAqJWAC9qMlG/C4e6d8OdSBS8OmM0ig==",
+      "dependencies": {
+        "@contentful/f36-collapse": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-asset": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.40.0.tgz",
+      "integrity": "sha512-trsduaUneIIz0giBXzgLqToXm6YgdpdzAZMXRDn2a6lKOc3lAhmAYiVb02NWxGtrUu9O7SACufjYrKI0Cx8pow==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icon": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-autocomplete": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.40.0.tgz",
+      "integrity": "sha512-lLYucmZvbse4D9ND0KR0ZMITF/sHYKXkaXxXMVWz8him4TBWXEHZ+OFFPzvzgNV0ocCww8+iSWxd9ls0JK8ZPg==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-forms": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-popover": "^4.40.0",
+        "@contentful/f36-skeleton": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "downshift": "^6.1.12",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-autocomplete/node_modules/downshift": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+      "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.8",
+        "compute-scroll-into-view": "^1.0.17",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-badge": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.40.0.tgz",
+      "integrity": "sha512-2YYxbUS/atR2/xDK7bTdXI3ElLAr2Mn93ys9sR2o+XnFW/wOUgi9UiS26y7zY8oWYyRElfQNCw8vYy4UqBAyZA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-button": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.40.0.tgz",
+      "integrity": "sha512-LzW1LRNq3cWotZMC9V1wYyr1m9lyryVOnicGLaV8TEvmSpteNoBVmG2s90emK7ruYYcGz/JrRCYIYkbfh1HUww==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-spinner": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-card": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.40.0.tgz",
+      "integrity": "sha512-KdNlo1n9Nczy/BPJ3uucdkeArKiPeiFIgNjeM5c3oSco233anc/RqmpypK2mrF6sXqF/VYIfjtatzSa9LAkzWQ==",
+      "dependencies": {
+        "@contentful/f36-asset": "^4.40.0",
+        "@contentful/f36-badge": "^4.40.0",
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-drag-handle": "^4.40.0",
+        "@contentful/f36-icon": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.40.0",
+        "@contentful/f36-skeleton": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.40.0",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17",
+        "truncate": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-collapse": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.40.0.tgz",
+      "integrity": "sha512-+1Abd7hiuR1B+KHwkGZ9XRWlqNz9VD/U9QQI1kouTMsKT5vBcwitgQ9ua9WHdLcK17lIrLilmNuN01PNNjVhwA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-copybutton": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.40.0.tgz",
+      "integrity": "sha512-3y1WP1wDgzXb86NAk1U+a0WlXA9kaXT3t0d2wO6PA0Vx4cJrinUsXmc9NiQ1qcy4DI///NN/E78oltbw8PkcSQ==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-core": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.40.0.tgz",
+      "integrity": "sha512-XNXhvhloELHG23jtXbd6LFFIdg2zINGESWoIAlkNt+B0rl0Mj/YdhLYrIujrWNZnQsczAcgKC7z2+sjK/e9avg==",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.0.1",
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-core/node_modules/@emotion/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datepicker": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.40.0.tgz",
+      "integrity": "sha512-Nc3UPjDFo99RqGRXJpAVLJKPpAksPncKKOjMG1NqehN2bOCJlHhgUZY3HcAkRUK8wl8ApuiIRW3dZ5jri8BN5g==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-forms": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-popover": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-typography": "^4.40.0",
+        "date-fns": "^2.28.0",
+        "emotion": "^10.0.17",
+        "react-day-picker": "^8.3.5",
+        "react-focus-lock": "^2.9.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datepicker/node_modules/react-day-picker": {
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.7.1.tgz",
+      "integrity": "sha512-Gv426AW8b151CZfh3aP5RUGztLwHB/EyJgWZ5iMgtzbFBkjHfG6Y66CIQFMWGLnYjsQ9DYSJRmJ5S0Pg5HWKjA==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datepicker/node_modules/react-focus-lock": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
+      "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.11.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.0",
+        "use-sidecar": "^1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datepicker/node_modules/react-focus-lock/node_modules/react-clientside-effect": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+      "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datepicker/node_modules/react-focus-lock/node_modules/use-callback-ref": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datepicker/node_modules/react-focus-lock/node_modules/use-sidecar": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+      "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-datetime": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.40.0.tgz",
+      "integrity": "sha512-1nbNlvvkFUSd5jEHOVAj2IQc+hmrjHSE9/18reBajuS4C3uTIWUU/0HI3uBx34+MVgl6r0Vwq2+BRNa5cFaSDw==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "dayjs": "^1.11.5",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-drag-handle": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.40.0.tgz",
+      "integrity": "sha512-yoWc+uF1p8ctiUHd0zwmLPY6hMrXDUzkF3GRqSnWggExUjo4+fASRWJIuuwRfuXFvYlFipAKeF7JMzJt7Wm/YA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-empty-state": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.40.0.tgz",
+      "integrity": "sha512-/23R+MsWnECcKFBKVQxMLah24AUMdRG+Tcwffc8yOJNQvXX/swnympGKUworbG+0GhBq1SAtepKofmBjYaC9yA==",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-entity-list": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.40.0.tgz",
+      "integrity": "sha512-9ZNtWycmsyUQpTCIHXZWSK59lr5xR7rqRD9G+z92Qe/B1gZ30ropP+z0igBCDwz9wFaxU18ObSpvLU+Q3Wc61w==",
+      "dependencies": {
+        "@contentful/f36-badge": "^4.40.0",
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-drag-handle": "^4.40.0",
+        "@contentful/f36-icon": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-menu": "^4.40.0",
+        "@contentful/f36-skeleton": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-forms": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.40.0.tgz",
+      "integrity": "sha512-NtAH03prbKzsaGnExhTXk/nrBCoDibUTBMh+HIEN14WeOgkGhFDLk3t3vlvfsSMQCXUjhVNA1svUfAIGYJjwMg==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-icon": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.40.0.tgz",
+      "integrity": "sha512-i9t3ct3iyfsA+5lMf01cdCiay2S5jNy1lNw3XE9cSG7k2F7T+8tKUv6cA54iG82ViLFtn/g9fxDin+R2XK88lQ==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-icons": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
+      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.23.2",
+        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-list": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.40.0.tgz",
+      "integrity": "sha512-Q2WHSbvGoYiGZVfc4+edjazMbnHdEfNrVzvR/riMh4hHcFkt1wnudya4gZGb56b4VMkhu/ai3bfJtZB7GIMDnQ==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-menu": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.40.0.tgz",
+      "integrity": "sha512-8I3XRGXlmhaxefU7fFqs6iWvorHspb+Hs2bD9aeusApnA253C45CCQFSWBFK6LTYzgT+Y8u5Pacu+uXQAcdBqQ==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-popover": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-modal": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.40.0.tgz",
+      "integrity": "sha512-ripsqOsLBTgugWfBDlvk7xkYcMfS7PsMgq0w1XVEcbs6oCBtTg8TuVkFKbxjt0DXSdUyK6DkZyeex6M/I8dT6w==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "@types/react-modal": "^3.13.1",
+        "emotion": "^10.0.17",
+        "react-modal": "^3.16.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-modal/node_modules/react-modal": {
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-note": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.40.0.tgz",
+      "integrity": "sha512-IdrxZziVThvtx30gpkl9jRD+UAOcpU0Ov3EhNVHj0z+D42p3YIAiz9+FVxS5Wy887AS+Ohb46a1M+DD6oUNixQ==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icon": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-notification": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.40.0.tgz",
+      "integrity": "sha512-3b2QbEmy7lRVBVX3vl0bICZUpGe73YkJxVXqeDFYUOllXy0rM9BQFlXg/boa4S1DO8kOuMOCO+HjAS6ypnUtEA==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-text-link": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "@swc/helpers": "^0.4.14",
+        "emotion": "^10.0.17",
+        "react-animate-height": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-notification/node_modules/react-animate-height": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
+      "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-pagination": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.40.0.tgz",
+      "integrity": "sha512-cXz3brGqUUufk+8yb+gWgniyQKy0C1tEgEuY1S05e2s+JkB5tFFBXfLo5zSgRNcJ+H0EyQ4Pi3rg+2L1MfvnZA==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-forms": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.0",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-pill": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.40.0.tgz",
+      "integrity": "sha512-e3DLLZikXrhmrUmAeuZqb076DrtVYZMmKYTudNZsv+o/3S18ZkjyvwDkNWc7igy32sap5op3tVRkv7zO7Cllvw==",
+      "dependencies": {
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-popover": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.40.0.tgz",
+      "integrity": "sha512-vlCzSjkpjcjskeQGNRyrwxaa1daqZBvwVsIqL032YwRTjk/I2SlhhPAUy5+G8GA1yumxlmPI7pQlSM9leKXVcw==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "@popperjs/core": "^2.11.5",
+        "emotion": "^10.0.17",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-popover/node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-skeleton": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.40.0.tgz",
+      "integrity": "sha512-65WDM9Tj4PPf0mGBzTgF7BkssK/GOKLlBwk7M7HCqtvFaQIyNV/2VeKqZm8RFu9fp0btnOnCI/bODC43eRhhtw==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-table": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-spinner": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.40.0.tgz",
+      "integrity": "sha512-rGTjIuUt0drUtb+sJnLyNAuBPf2qbHsHejJyrYQAUG+0ia4jO8589V5szq0deMqv9naNy6je0KPca0wv38MV3A==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-table": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.40.0.tgz",
+      "integrity": "sha512-J9MMIgjL1SvISYdcRlClKWMbovvB9t8sLznMGQCpdBYUtz5T4Gw0ncrvNhiSAnbISVSrJ2/WIeM1NYhv5mj8YQ==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-icons": "^4.25.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-typography": "^4.40.0",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.40.0.tgz",
+      "integrity": "sha512-nsTZSaeFPfClPFz+xIVzj27PdysRtMv8laORbbJtJMn+z1l72Q/scMqw8L2HTFlLvzwYY3gJx+rwqBq/FE1dDA==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@radix-ui/react-tabs": "^1.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
+      "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-direction": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-presence": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-roving-focus": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+      "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-direction": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+      "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+      "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-id/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+      "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-use-layout-effect": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
+      "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
+      "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.0",
+        "@radix-ui/react-collection": "1.0.2",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-direction": "1.0.0",
+        "@radix-ui/react-id": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-use-callback-ref": "1.0.0",
+        "@radix-ui/react-use-controllable-state": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
+      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0",
+        "@radix-ui/react-context": "1.0.0",
+        "@radix-ui/react-primitive": "1.0.2",
+        "@radix-ui/react-slot": "1.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+      "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-callback-ref": "1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tabs/node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-text-link": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.40.0.tgz",
+      "integrity": "sha512-BVzdfRZVhIVIJW2UFfR8uD0vFmUcakOv8GBfmX85WWDS2PwxK6uwV8TZyud9+6iyzzzd7dmBYMVn0aCnnlp8Tg==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tooltip": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.40.0.tgz",
+      "integrity": "sha512-E2H6qbE63GGmAfnY1I/eLBtnrDNAILWt19p4LUKYHqiI88c/pjMiOnXafx2C5U7hXfiWCmIvA69RvrWvJtjCTw==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-utils": "^4.23.2",
+        "@popperjs/core": "^2.11.5",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-tooltip/node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-typography": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.40.0.tgz",
+      "integrity": "sha512-897pXqTEmq9EyuA/adHTlmCP823X3iiVmcF4oSUzIgFPqk8HsIX8sXk90UPE89UYFQhywIuZ5M+yGMiIZwSzew==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-utils": {
+      "version": "4.24.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
+      "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+      "dependencies": {
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/@contentful/f36-components/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/@contentful/f36-components/node_modules/truncate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
+      "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@contentful/f36-components/node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/@contentful/f36-tokens": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.1.tgz",
+      "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
+    },
     "node_modules/@contentful/field-editor-shared": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.10.4.tgz",
@@ -2012,6 +3043,14 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.5.3.tgz",
       "integrity": "sha512-cFNVjX/a4Sk2rTTryupgCb7u0IcNQlH7r6ztaxLEUHg56XD4KIUAFqgf+nd9ndeSilYGosm7NjXCTE4Sep0fVw=="
     },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.1.0.tgz",
+      "integrity": "sha512-Pucb68FK0j9cHJ96FAewXv+bvH4XizC4KBbVqyHhPLkDIVfasj0AWU5rI1lnvysdVKu66NQkFe8xZdeFTkaLWQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -2036,10 +3075,33 @@
         "@emotion/weak-memoize": "0.2.5"
       }
     },
+    "node_modules/@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "dependencies": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/memoize": {
       "version": "0.7.4",
@@ -2842,6 +3904,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -3246,6 +4325,14 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -3655,8 +4742,7 @@
     "node_modules/@types/json-patch": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json-patch/-/json-patch-0.0.30.tgz",
-      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw==",
-      "peer": true
+      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
@@ -3704,21 +4790,35 @@
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "node_modules/@types/react": {
-      "version": "16.9.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
+      "version": "16.14.22",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
+      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "16.9.8",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
-      "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
+      "version": "16.9.14",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
+      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "dependencies": {
+        "@types/react": "^16"
+      }
+    },
+    "node_modules/@types/react-modal": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
+      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/react/node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/@types/resolve": {
       "version": "0.0.8",
@@ -3727,6 +4827,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -6167,6 +7272,11 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6247,43 +7357,58 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/contentful-management": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.49.0.tgz",
-      "integrity": "sha512-9Y7nI2S1Y9Ysg3Fa8AGRi5mT2XntzxFVry+S2BHsvcdX/hgGyllf/Xbmm6TRahpeS1nPozDJk1AC1Y/K3mCagw==",
-      "peer": true,
+    "node_modules/contentful": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.2.0.tgz",
+      "integrity": "sha512-jygmcO4u/1gVzobgoQCja7mBV+4JZyeNOvoZ8Yv13g/7w6nY+NoMUPTuE0YK/CJLVTYI7sW4HMuuFParI/etOQ==",
       "dependencies": {
-        "@types/json-patch": "0.0.30",
-        "axios": "^0.21.4",
-        "contentful-sdk-core": "^6.10.4",
-        "fast-copy": "^2.1.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^2.5.3"
+        "@contentful/rich-text-types": "^16.0.2",
+        "axios": "^0.26.1",
+        "contentful-resolve-response": "^1.3.6",
+        "contentful-sdk-core": "^7.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "type-fest": "^3.1.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      }
+    },
+    "node_modules/contentful-management": {
+      "version": "10.35.3",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.35.3.tgz",
+      "integrity": "sha512-kX/dIfIChAViTkjYZdTzj2Yf3PF7G1kXgLf44qwaE9rwv2tZ5/MjYrqZhDCDxaSBREhD9NZWpsXWPGDD5I2CLw==",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.0.3",
+        "@types/json-patch": "0.0.30",
+        "axios": "^0.27.1",
+        "contentful-sdk-core": "^7.0.1",
+        "fast-copy": "^3.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "type-fest": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/contentful-management/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "peer": true,
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/contentful-management/node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -6293,33 +7418,81 @@
         }
       }
     },
-    "node_modules/contentful-management/node_modules/type-fest": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.9.0.tgz",
-      "integrity": "sha512-uC0hJKi7eAGXUJ/YKk53RhnKxMwzHWgzf4t92oz8Qez28EBgVTfpDTB59y9hMYLzc/Wl85cD7Tv1hLZZoEJtrg==",
-      "peer": true,
+    "node_modules/contentful-management/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
       "engines": {
-        "node": ">=12.20"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/contentful-management/node_modules/type-fest": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
+      "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7.0"
       }
     },
-    "node_modules/contentful-sdk-core": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.10.4.tgz",
-      "integrity": "sha512-vnivU13pKqFzs/eEugqOaDkKce6ZljBkpp6l25MsG8LA1HPCQNBnIkqP5VUbwk/ub7tkHteV9HtoTnmpdvB+Zg==",
+    "node_modules/contentful-management/node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/contentful-resolve-response": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.7.0.tgz",
+      "integrity": "sha512-NIaQkXAdNWf/1wp13aqtrmHWHy71oCIIbynojGs9ONDtA7hBXC2yCEf2IjzfgOkrkEfOMvwDQHizD0WmL6FR8w==",
       "dependencies": {
-        "fast-copy": "^2.1.0",
+        "fast-copy": "^2.1.7"
+      },
+      "engines": {
+        "node": ">=4.7.2"
+      }
+    },
+    "node_modules/contentful-resolve-response/node_modules/fast-copy": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+    },
+    "node_modules/contentful-sdk-core": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
+      "integrity": "sha512-RzTPnRsbCdVAhyka3wa9sDsAu9YsxoerNgaMqd63Ljb7qpG2zkdHcP7NTfyIbuHDJNJdAQdifyafxfEEwP+q/w==",
+      "dependencies": {
+        "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
         "qs": "^6.9.4"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
+    },
+    "node_modules/contentful-sdk-core/node_modules/fast-copy": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
     },
     "node_modules/contentful-ui-extensions-sdk": {
       "version": "4.3.1",
@@ -6327,6 +7500,60 @@
       "integrity": "sha512-ht8vPXBaBcGqzxvn+Di3hGWEcfkbBSzhfvkw9QLqVuKq9oPariLAgIwC75dfsmsfF9Ctljiy2sop6l5I2nFdDw==",
       "peerDependencies": {
         "contentful-management": "^7.30.0"
+      }
+    },
+    "node_modules/contentful/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/contentful/node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/contentful/node_modules/type-fest": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
+      "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/contentful/node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/convert-source-map": {
@@ -6999,6 +8226,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+    },
     "node_modules/debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -7317,6 +8564,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/detect-port-alt": {
       "version": "1.1.6",
@@ -9075,10 +10327,9 @@
       }
     },
     "node_modules/fast-copy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.1.tgz",
-      "integrity": "sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==",
-      "peer": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9310,6 +10561,17 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "node_modules/focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/follow-redirects": {
@@ -12157,6 +13419,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "node_modules/json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -12347,14 +13614,12 @@
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "peer": true
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "peer": true
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -13504,7 +14769,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
       "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15566,6 +16830,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
+      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -15949,9 +17218,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -18725,9 +19994,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -22180,11 +23449,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -22279,6 +23548,807 @@
         "minimist": "^1.2.0"
       }
     },
+    "@contentful/f36-components": {
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-components/-/f36-components-4.40.0.tgz",
+      "integrity": "sha512-oEin2WmigFSITuh2MiCMGvOPdAyzJaw4VxTF6UBZjeOtX/ZA0Vf9ByyOgYh1ugVnrYH/wGF3E9Qno33LYWQZCQ==",
+      "requires": {
+        "@contentful/f36-accordion": "^4.40.0",
+        "@contentful/f36-asset": "^4.40.0",
+        "@contentful/f36-autocomplete": "^4.40.0",
+        "@contentful/f36-badge": "^4.40.0",
+        "@contentful/f36-button": "^4.40.0",
+        "@contentful/f36-card": "^4.40.0",
+        "@contentful/f36-collapse": "^4.40.0",
+        "@contentful/f36-copybutton": "^4.40.0",
+        "@contentful/f36-core": "^4.40.0",
+        "@contentful/f36-datepicker": "^4.40.0",
+        "@contentful/f36-datetime": "^4.40.0",
+        "@contentful/f36-drag-handle": "^4.40.0",
+        "@contentful/f36-empty-state": "^4.40.0",
+        "@contentful/f36-entity-list": "^4.40.0",
+        "@contentful/f36-forms": "^4.40.0",
+        "@contentful/f36-icon": "^4.40.0",
+        "@contentful/f36-icons": "^4.23.2",
+        "@contentful/f36-list": "^4.40.0",
+        "@contentful/f36-menu": "^4.40.0",
+        "@contentful/f36-modal": "^4.40.0",
+        "@contentful/f36-note": "^4.40.0",
+        "@contentful/f36-notification": "^4.40.0",
+        "@contentful/f36-pagination": "^4.40.0",
+        "@contentful/f36-pill": "^4.40.0",
+        "@contentful/f36-popover": "^4.40.0",
+        "@contentful/f36-skeleton": "^4.40.0",
+        "@contentful/f36-spinner": "^4.40.0",
+        "@contentful/f36-table": "^4.40.0",
+        "@contentful/f36-tabs": "^4.40.0",
+        "@contentful/f36-text-link": "^4.40.0",
+        "@contentful/f36-tokens": "^4.0.1",
+        "@contentful/f36-tooltip": "^4.40.0",
+        "@contentful/f36-typography": "^4.40.0",
+        "@contentful/f36-utils": "^4.23.2",
+        "@types/react": "16.14.22",
+        "@types/react-dom": "16.9.14"
+      },
+      "dependencies": {
+        "@contentful/f36-accordion": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-accordion/-/f36-accordion-4.40.0.tgz",
+          "integrity": "sha512-csALGciWyL0FId4tpAwSLwpyqyjWI9U/pB2I2HDgA75uyxZWnVBTcKQnAqJWAC9qMlG/C4e6d8OdSBS8OmM0ig==",
+          "requires": {
+            "@contentful/f36-collapse": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-asset": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-asset/-/f36-asset-4.40.0.tgz",
+          "integrity": "sha512-trsduaUneIIz0giBXzgLqToXm6YgdpdzAZMXRDn2a6lKOc3lAhmAYiVb02NWxGtrUu9O7SACufjYrKI0Cx8pow==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icon": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-autocomplete": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-autocomplete/-/f36-autocomplete-4.40.0.tgz",
+          "integrity": "sha512-lLYucmZvbse4D9ND0KR0ZMITF/sHYKXkaXxXMVWz8him4TBWXEHZ+OFFPzvzgNV0ocCww8+iSWxd9ls0JK8ZPg==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-forms": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-popover": "^4.40.0",
+            "@contentful/f36-skeleton": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "@contentful/f36-utils": "^4.23.2",
+            "downshift": "^6.1.12",
+            "emotion": "^10.0.17"
+          },
+          "dependencies": {
+            "downshift": {
+              "version": "6.1.12",
+              "resolved": "https://registry.npmjs.org/downshift/-/downshift-6.1.12.tgz",
+              "integrity": "sha512-7XB/iaSJVS4T8wGFT3WRXmSF1UlBHAA40DshZtkrIscIN+VC+Lh363skLxFTvJwtNgHxAMDGEHT4xsyQFWL+UA==",
+              "requires": {
+                "@babel/runtime": "^7.14.8",
+                "compute-scroll-into-view": "^1.0.17",
+                "prop-types": "^15.7.2",
+                "react-is": "^17.0.2",
+                "tslib": "^2.3.0"
+              }
+            }
+          }
+        },
+        "@contentful/f36-badge": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-badge/-/f36-badge-4.40.0.tgz",
+          "integrity": "sha512-2YYxbUS/atR2/xDK7bTdXI3ElLAr2Mn93ys9sR2o+XnFW/wOUgi9UiS26y7zY8oWYyRElfQNCw8vYy4UqBAyZA==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-button": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-button/-/f36-button-4.40.0.tgz",
+          "integrity": "sha512-LzW1LRNq3cWotZMC9V1wYyr1m9lyryVOnicGLaV8TEvmSpteNoBVmG2s90emK7ruYYcGz/JrRCYIYkbfh1HUww==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-spinner": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-card": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-card/-/f36-card-4.40.0.tgz",
+          "integrity": "sha512-KdNlo1n9Nczy/BPJ3uucdkeArKiPeiFIgNjeM5c3oSco233anc/RqmpypK2mrF6sXqF/VYIfjtatzSa9LAkzWQ==",
+          "requires": {
+            "@contentful/f36-asset": "^4.40.0",
+            "@contentful/f36-badge": "^4.40.0",
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-drag-handle": "^4.40.0",
+            "@contentful/f36-icon": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-menu": "^4.40.0",
+            "@contentful/f36-skeleton": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-tooltip": "^4.40.0",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17",
+            "truncate": "^3.0.0"
+          }
+        },
+        "@contentful/f36-collapse": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-collapse/-/f36-collapse-4.40.0.tgz",
+          "integrity": "sha512-+1Abd7hiuR1B+KHwkGZ9XRWlqNz9VD/U9QQI1kouTMsKT5vBcwitgQ9ua9WHdLcK17lIrLilmNuN01PNNjVhwA==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-copybutton": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-copybutton/-/f36-copybutton-4.40.0.tgz",
+          "integrity": "sha512-3y1WP1wDgzXb86NAk1U+a0WlXA9kaXT3t0d2wO6PA0Vx4cJrinUsXmc9NiQ1qcy4DI///NN/E78oltbw8PkcSQ==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-tooltip": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-core": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.40.0.tgz",
+          "integrity": "sha512-XNXhvhloELHG23jtXbd6LFFIdg2zINGESWoIAlkNt+B0rl0Mj/YdhLYrIujrWNZnQsczAcgKC7z2+sjK/e9avg==",
+          "requires": {
+            "@contentful/f36-tokens": "^4.0.1",
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^1.2.0",
+            "csstype": "^3.1.1",
+            "emotion": "^10.0.17"
+          },
+          "dependencies": {
+            "@emotion/core": {
+              "version": "10.3.1",
+              "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+              "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+              "requires": {
+                "@babel/runtime": "^7.5.5",
+                "@emotion/cache": "^10.0.27",
+                "@emotion/css": "^10.0.27",
+                "@emotion/serialize": "^0.11.15",
+                "@emotion/sheet": "0.9.4",
+                "@emotion/utils": "0.11.3"
+              }
+            }
+          }
+        },
+        "@contentful/f36-datepicker": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-datepicker/-/f36-datepicker-4.40.0.tgz",
+          "integrity": "sha512-Nc3UPjDFo99RqGRXJpAVLJKPpAksPncKKOjMG1NqehN2bOCJlHhgUZY3HcAkRUK8wl8ApuiIRW3dZ5jri8BN5g==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-forms": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-popover": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.0",
+            "@contentful/f36-typography": "^4.40.0",
+            "date-fns": "^2.28.0",
+            "emotion": "^10.0.17",
+            "react-day-picker": "^8.3.5",
+            "react-focus-lock": "^2.9.1"
+          },
+          "dependencies": {
+            "react-day-picker": {
+              "version": "8.7.1",
+              "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.7.1.tgz",
+              "integrity": "sha512-Gv426AW8b151CZfh3aP5RUGztLwHB/EyJgWZ5iMgtzbFBkjHfG6Y66CIQFMWGLnYjsQ9DYSJRmJ5S0Pg5HWKjA==",
+              "requires": {}
+            },
+            "react-focus-lock": {
+              "version": "2.9.4",
+              "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.9.4.tgz",
+              "integrity": "sha512-7pEdXyMseqm3kVjhdVH18sovparAzLg5h6WvIx7/Ck3ekjhrrDMEegHSa3swwC8wgfdd7DIdUVRGeiHT9/7Sgg==",
+              "requires": {
+                "@babel/runtime": "^7.0.0",
+                "focus-lock": "^0.11.6",
+                "prop-types": "^15.6.2",
+                "react-clientside-effect": "^1.2.6",
+                "use-callback-ref": "^1.3.0",
+                "use-sidecar": "^1.1.2"
+              },
+              "dependencies": {
+                "react-clientside-effect": {
+                  "version": "1.2.6",
+                  "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz",
+                  "integrity": "sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==",
+                  "requires": {
+                    "@babel/runtime": "^7.12.13"
+                  }
+                },
+                "use-callback-ref": {
+                  "version": "1.3.0",
+                  "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+                  "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+                  "requires": {
+                    "tslib": "^2.0.0"
+                  }
+                },
+                "use-sidecar": {
+                  "version": "1.1.2",
+                  "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+                  "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+                  "requires": {
+                    "detect-node-es": "^1.1.0",
+                    "tslib": "^2.0.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@contentful/f36-datetime": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-datetime/-/f36-datetime-4.40.0.tgz",
+          "integrity": "sha512-1nbNlvvkFUSd5jEHOVAj2IQc+hmrjHSE9/18reBajuS4C3uTIWUU/0HI3uBx34+MVgl6r0Vwq2+BRNa5cFaSDw==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "dayjs": "^1.11.5",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-drag-handle": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-drag-handle/-/f36-drag-handle-4.40.0.tgz",
+          "integrity": "sha512-yoWc+uF1p8ctiUHd0zwmLPY6hMrXDUzkF3GRqSnWggExUjo4+fASRWJIuuwRfuXFvYlFipAKeF7JMzJt7Wm/YA==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-utils": "^4.23.2",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-empty-state": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-empty-state/-/f36-empty-state-4.40.0.tgz",
+          "integrity": "sha512-/23R+MsWnECcKFBKVQxMLah24AUMdRG+Tcwffc8yOJNQvXX/swnympGKUworbG+0GhBq1SAtepKofmBjYaC9yA==",
+          "requires": {
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-entity-list": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-entity-list/-/f36-entity-list-4.40.0.tgz",
+          "integrity": "sha512-9ZNtWycmsyUQpTCIHXZWSK59lr5xR7rqRD9G+z92Qe/B1gZ30ropP+z0igBCDwz9wFaxU18ObSpvLU+Q3Wc61w==",
+          "requires": {
+            "@contentful/f36-badge": "^4.40.0",
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-drag-handle": "^4.40.0",
+            "@contentful/f36-icon": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-menu": "^4.40.0",
+            "@contentful/f36-skeleton": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-forms": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-forms/-/f36-forms-4.40.0.tgz",
+          "integrity": "sha512-NtAH03prbKzsaGnExhTXk/nrBCoDibUTBMh+HIEN14WeOgkGhFDLk3t3vlvfsSMQCXUjhVNA1svUfAIGYJjwMg==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-icon": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.40.0.tgz",
+          "integrity": "sha512-i9t3ct3iyfsA+5lMf01cdCiay2S5jNy1lNw3XE9cSG7k2F7T+8tKUv6cA54iG82ViLFtn/g9fxDin+R2XK88lQ==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-icons": {
+          "version": "4.25.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
+          "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+          "requires": {
+            "@contentful/f36-core": "^4.23.2",
+            "@contentful/f36-icon": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-list": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.40.0.tgz",
+          "integrity": "sha512-Q2WHSbvGoYiGZVfc4+edjazMbnHdEfNrVzvR/riMh4hHcFkt1wnudya4gZGb56b4VMkhu/ai3bfJtZB7GIMDnQ==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-menu": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-menu/-/f36-menu-4.40.0.tgz",
+          "integrity": "sha512-8I3XRGXlmhaxefU7fFqs6iWvorHspb+Hs2bD9aeusApnA253C45CCQFSWBFK6LTYzgT+Y8u5Pacu+uXQAcdBqQ==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-popover": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "@contentful/f36-utils": "^4.23.2",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-modal": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-modal/-/f36-modal-4.40.0.tgz",
+          "integrity": "sha512-ripsqOsLBTgugWfBDlvk7xkYcMfS7PsMgq0w1XVEcbs6oCBtTg8TuVkFKbxjt0DXSdUyK6DkZyeex6M/I8dT6w==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "@types/react-modal": "^3.13.1",
+            "emotion": "^10.0.17",
+            "react-modal": "^3.16.1"
+          },
+          "dependencies": {
+            "react-modal": {
+              "version": "3.16.1",
+              "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
+              "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+              "requires": {
+                "exenv": "^1.2.0",
+                "prop-types": "^15.7.2",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^4.0.3"
+              }
+            }
+          }
+        },
+        "@contentful/f36-note": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-note/-/f36-note-4.40.0.tgz",
+          "integrity": "sha512-IdrxZziVThvtx30gpkl9jRD+UAOcpU0Ov3EhNVHj0z+D42p3YIAiz9+FVxS5Wy887AS+Ohb46a1M+DD6oUNixQ==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icon": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-notification": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-notification/-/f36-notification-4.40.0.tgz",
+          "integrity": "sha512-3b2QbEmy7lRVBVX3vl0bICZUpGe73YkJxVXqeDFYUOllXy0rM9BQFlXg/boa4S1DO8kOuMOCO+HjAS6ypnUtEA==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-text-link": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "@swc/helpers": "^0.4.14",
+            "emotion": "^10.0.17",
+            "react-animate-height": "^3.0.4"
+          },
+          "dependencies": {
+            "react-animate-height": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-3.1.1.tgz",
+              "integrity": "sha512-UkC6+V3ZlCneBRaSM7aUctDJ+PRP6ztcGtxvU7MTeoMMWPhz8BQNaX7QWaZrkzp1ih1G8uZZ+DI9nfLvtD6OdQ==",
+              "requires": {}
+            }
+          }
+        },
+        "@contentful/f36-pagination": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-pagination/-/f36-pagination-4.40.0.tgz",
+          "integrity": "sha512-cXz3brGqUUufk+8yb+gWgniyQKy0C1tEgEuY1S05e2s+JkB5tFFBXfLo5zSgRNcJ+H0EyQ4Pi3rg+2L1MfvnZA==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-forms": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.0",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-pill": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-pill/-/f36-pill-4.40.0.tgz",
+          "integrity": "sha512-e3DLLZikXrhmrUmAeuZqb076DrtVYZMmKYTudNZsv+o/3S18ZkjyvwDkNWc7igy32sap5op3tVRkv7zO7Cllvw==",
+          "requires": {
+            "@contentful/f36-button": "^4.40.0",
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.23.2",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-tooltip": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-popover": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-popover/-/f36-popover-4.40.0.tgz",
+          "integrity": "sha512-vlCzSjkpjcjskeQGNRyrwxaa1daqZBvwVsIqL032YwRTjk/I2SlhhPAUy5+G8GA1yumxlmPI7pQlSM9leKXVcw==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-utils": "^4.23.2",
+            "@popperjs/core": "^2.11.5",
+            "emotion": "^10.0.17",
+            "react-popper": "^2.3.0"
+          },
+          "dependencies": {
+            "react-popper": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+              "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+              "requires": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+              }
+            }
+          }
+        },
+        "@contentful/f36-skeleton": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-skeleton/-/f36-skeleton-4.40.0.tgz",
+          "integrity": "sha512-65WDM9Tj4PPf0mGBzTgF7BkssK/GOKLlBwk7M7HCqtvFaQIyNV/2VeKqZm8RFu9fp0btnOnCI/bODC43eRhhtw==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-table": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-spinner": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-spinner/-/f36-spinner-4.40.0.tgz",
+          "integrity": "sha512-rGTjIuUt0drUtb+sJnLyNAuBPf2qbHsHejJyrYQAUG+0ia4jO8589V5szq0deMqv9naNy6je0KPca0wv38MV3A==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-table": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-table/-/f36-table-4.40.0.tgz",
+          "integrity": "sha512-J9MMIgjL1SvISYdcRlClKWMbovvB9t8sLznMGQCpdBYUtz5T4Gw0ncrvNhiSAnbISVSrJ2/WIeM1NYhv5mj8YQ==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-icons": "^4.25.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-typography": "^4.40.0",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-tabs": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-tabs/-/f36-tabs-4.40.0.tgz",
+          "integrity": "sha512-nsTZSaeFPfClPFz+xIVzj27PdysRtMv8laORbbJtJMn+z1l72Q/scMqw8L2HTFlLvzwYY3gJx+rwqBq/FE1dDA==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@radix-ui/react-tabs": "^1.0.1",
+            "emotion": "^10.0.17"
+          },
+          "dependencies": {
+            "@radix-ui/react-tabs": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.3.tgz",
+              "integrity": "sha512-4CkF/Rx1GcrusI/JZ1Rvyx4okGUs6wEenWA0RG/N+CwkRhTy7t54y7BLsWUXrAz/GRbBfHQg/Odfs/RoW0CiRA==",
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.0",
+                "@radix-ui/react-context": "1.0.0",
+                "@radix-ui/react-direction": "1.0.0",
+                "@radix-ui/react-id": "1.0.0",
+                "@radix-ui/react-presence": "1.0.0",
+                "@radix-ui/react-primitive": "1.0.2",
+                "@radix-ui/react-roving-focus": "1.0.3",
+                "@radix-ui/react-use-controllable-state": "1.0.0"
+              },
+              "dependencies": {
+                "@radix-ui/react-context": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+                  "integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                },
+                "@radix-ui/react-direction": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+                  "integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10"
+                  }
+                },
+                "@radix-ui/react-id": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+                  "integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-use-layout-effect": "1.0.0"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-use-layout-effect": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+                      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    }
+                  }
+                },
+                "@radix-ui/react-presence": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.0.tgz",
+                  "integrity": "sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-compose-refs": "1.0.0",
+                    "@radix-ui/react-use-layout-effect": "1.0.0"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-compose-refs": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+                      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    },
+                    "@radix-ui/react-use-layout-effect": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+                      "integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    }
+                  }
+                },
+                "@radix-ui/react-primitive": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.2.tgz",
+                  "integrity": "sha512-zY6G5Qq4R8diFPNwtyoLRZBxzu1Z+SXMlfYpChN7Dv8gvmx9X3qhDqiLWvKseKVJMuedFeU/Sa0Sy/Ia+t06Dw==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-slot": "1.0.1"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-slot": {
+                      "version": "1.0.1",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+                      "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10",
+                        "@radix-ui/react-compose-refs": "1.0.0"
+                      },
+                      "dependencies": {
+                        "@radix-ui/react-compose-refs": {
+                          "version": "1.0.0",
+                          "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+                          "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+                          "requires": {
+                            "@babel/runtime": "^7.13.10"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "@radix-ui/react-roving-focus": {
+                  "version": "1.0.3",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.3.tgz",
+                  "integrity": "sha512-stjCkIoMe6h+1fWtXlA6cRfikdBzCLp3SnVk7c48cv/uy3DTGoXhN76YaOYUJuy3aEDvDIKwKR5KSmvrtPvQPQ==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/primitive": "1.0.0",
+                    "@radix-ui/react-collection": "1.0.2",
+                    "@radix-ui/react-compose-refs": "1.0.0",
+                    "@radix-ui/react-context": "1.0.0",
+                    "@radix-ui/react-direction": "1.0.0",
+                    "@radix-ui/react-id": "1.0.0",
+                    "@radix-ui/react-primitive": "1.0.2",
+                    "@radix-ui/react-use-callback-ref": "1.0.0",
+                    "@radix-ui/react-use-controllable-state": "1.0.0"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-collection": {
+                      "version": "1.0.2",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.2.tgz",
+                      "integrity": "sha512-s8WdQQ6wNXpaxdZ308KSr8fEWGrg4un8i4r/w7fhiS4ElRNjk5rRcl0/C6TANG2LvLOGIxtzo/jAg6Qf73TEBw==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10",
+                        "@radix-ui/react-compose-refs": "1.0.0",
+                        "@radix-ui/react-context": "1.0.0",
+                        "@radix-ui/react-primitive": "1.0.2",
+                        "@radix-ui/react-slot": "1.0.1"
+                      },
+                      "dependencies": {
+                        "@radix-ui/react-slot": {
+                          "version": "1.0.1",
+                          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+                          "integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+                          "requires": {
+                            "@babel/runtime": "^7.13.10",
+                            "@radix-ui/react-compose-refs": "1.0.0"
+                          }
+                        }
+                      }
+                    },
+                    "@radix-ui/react-compose-refs": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+                      "integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    },
+                    "@radix-ui/react-use-callback-ref": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+                      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    }
+                  }
+                },
+                "@radix-ui/react-use-controllable-state": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+                  "integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+                  "requires": {
+                    "@babel/runtime": "^7.13.10",
+                    "@radix-ui/react-use-callback-ref": "1.0.0"
+                  },
+                  "dependencies": {
+                    "@radix-ui/react-use-callback-ref": {
+                      "version": "1.0.0",
+                      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+                      "integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+                      "requires": {
+                        "@babel/runtime": "^7.13.10"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@contentful/f36-text-link": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-text-link/-/f36-text-link-4.40.0.tgz",
+          "integrity": "sha512-BVzdfRZVhIVIJW2UFfR8uD0vFmUcakOv8GBfmX85WWDS2PwxK6uwV8TZyud9+6iyzzzd7dmBYMVn0aCnnlp8Tg==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-tooltip": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-tooltip/-/f36-tooltip-4.40.0.tgz",
+          "integrity": "sha512-E2H6qbE63GGmAfnY1I/eLBtnrDNAILWt19p4LUKYHqiI88c/pjMiOnXafx2C5U7hXfiWCmIvA69RvrWvJtjCTw==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "@contentful/f36-utils": "^4.23.2",
+            "@popperjs/core": "^2.11.5",
+            "csstype": "^3.1.1",
+            "emotion": "^10.0.17",
+            "react-popper": "^2.3.0"
+          },
+          "dependencies": {
+            "react-popper": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+              "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+              "requires": {
+                "react-fast-compare": "^3.0.1",
+                "warning": "^4.0.2"
+              }
+            }
+          }
+        },
+        "@contentful/f36-typography": {
+          "version": "4.40.0",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-typography/-/f36-typography-4.40.0.tgz",
+          "integrity": "sha512-897pXqTEmq9EyuA/adHTlmCP823X3iiVmcF4oSUzIgFPqk8HsIX8sXk90UPE89UYFQhywIuZ5M+yGMiIZwSzew==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.0",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "@contentful/f36-utils": {
+          "version": "4.24.1",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-utils/-/f36-utils-4.24.1.tgz",
+          "integrity": "sha512-jr+61KiKn7oA38WXgAJoqVNdr6gXzmJSA+MCl7Djapxxf+jsC1vsi8j8okISCm4a/ZcPncKekDYzzWu+kkI7VQ==",
+          "requires": {
+            "emotion": "^10.0.17"
+          }
+        },
+        "csstype": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        },
+        "truncate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/truncate/-/truncate-3.0.0.tgz",
+          "integrity": "sha512-C+0Xojw7wZPl6MDq5UjMTuxZvBPK04mtdFet7k+GSZPINcvLZFCXg+15kWIL4wAqDB7CksIsKiRLbQ1wa7rKdw=="
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@contentful/f36-tokens": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-tokens/-/f36-tokens-4.0.1.tgz",
+      "integrity": "sha512-NTyMAQcfvhPP8kJgOK5mtjKpErg799iglEb9B45ii4N7aMdph2GNqgv7KBgpogfbTEGBrlKIoH8MUDSV9YNREg=="
+    },
     "@contentful/field-editor-shared": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/@contentful/field-editor-shared/-/field-editor-shared-0.10.4.tgz",
@@ -22359,6 +24429,11 @@
       "resolved": "https://registry.npmjs.org/@contentful/forma-36-tokens/-/forma-36-tokens-0.5.3.tgz",
       "integrity": "sha512-cFNVjX/a4Sk2rTTryupgCb7u0IcNQlH7r6ztaxLEUHg56XD4KIUAFqgf+nd9ndeSilYGosm7NjXCTE4Sep0fVw=="
     },
+    "@contentful/rich-text-types": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.1.0.tgz",
+      "integrity": "sha512-Pucb68FK0j9cHJ96FAewXv+bvH4XizC4KBbVqyHhPLkDIVfasj0AWU5rI1lnvysdVKu66NQkFe8xZdeFTkaLWQ=="
+    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -22380,10 +24455,35 @@
         "@emotion/weak-memoize": "0.2.5"
       }
     },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
     "@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "requires": {
+        "@emotion/memoize": "^0.8.1"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+          "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+        }
+      }
     },
     "@emotion/memoize": {
       "version": "0.7.4",
@@ -23000,6 +25100,19 @@
         }
       }
     },
+    "@popperjs/core": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
+    },
+    "@radix-ui/primitive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+      "integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz",
@@ -23260,6 +25373,14 @@
             "json5": "^2.1.2"
           }
         }
+      }
+    },
+    "@swc/helpers": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
+      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@testing-library/dom": {
@@ -23606,8 +25727,7 @@
     "@types/json-patch": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json-patch/-/json-patch-0.0.30.tgz",
-      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw==",
-      "peer": true
+      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
     },
     "@types/json-schema": {
       "version": "7.0.9",
@@ -23655,18 +25775,34 @@
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
     "@types/react": {
-      "version": "16.9.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
+      "version": "16.14.22",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.22.tgz",
+      "integrity": "sha512-4NnkxKDd2UO9SiCckuhCQOCzdO+RtE4Epf1D6eGz3f9jZjiIXOVo+Bk3jqSad+8EOT+LBXwKdkFX0V0F+NFzDQ==",
       "requires": {
         "@types/prop-types": "*",
-        "csstype": "^2.2.0"
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        }
       }
     },
     "@types/react-dom": {
-      "version": "16.9.8",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
-      "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
+      "version": "16.9.14",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.14.tgz",
+      "integrity": "sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==",
+      "requires": {
+        "@types/react": "^16"
+      }
+    },
+    "@types/react-modal": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@types/react-modal/-/react-modal-3.16.0.tgz",
+      "integrity": "sha512-iphdqXAyUfByLbxJn5j6d+yh93dbMgshqGP0IuBeaKbZXx0aO+OXsvEkt6QctRdxjeM9/bR+Gp3h9F9djVWTQQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -23678,6 +25814,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
+      "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -25615,6 +27756,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -25671,54 +27817,130 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "contentful-management": {
-      "version": "7.49.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-7.49.0.tgz",
-      "integrity": "sha512-9Y7nI2S1Y9Ysg3Fa8AGRi5mT2XntzxFVry+S2BHsvcdX/hgGyllf/Xbmm6TRahpeS1nPozDJk1AC1Y/K3mCagw==",
-      "peer": true,
+    "contentful": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.2.0.tgz",
+      "integrity": "sha512-jygmcO4u/1gVzobgoQCja7mBV+4JZyeNOvoZ8Yv13g/7w6nY+NoMUPTuE0YK/CJLVTYI7sW4HMuuFParI/etOQ==",
       "requires": {
-        "@types/json-patch": "0.0.30",
-        "axios": "^0.21.4",
-        "contentful-sdk-core": "^6.10.4",
-        "fast-copy": "^2.1.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^2.5.3"
+        "@contentful/rich-text-types": "^16.0.2",
+        "axios": "^0.26.1",
+        "contentful-resolve-response": "^1.3.6",
+        "contentful-sdk-core": "^7.0.2",
+        "json-stringify-safe": "^5.0.1",
+        "type-fest": "^3.1.0"
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "peer": true,
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
           "requires": {
-            "follow-redirects": "^1.14.0"
+            "follow-redirects": "^1.14.8"
           }
         },
         "follow-redirects": {
-          "version": "1.14.7",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-          "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-          "peer": true
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
         },
         "type-fest": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.9.0.tgz",
-          "integrity": "sha512-uC0hJKi7eAGXUJ/YKk53RhnKxMwzHWgzf4t92oz8Qez28EBgVTfpDTB59y9hMYLzc/Wl85cD7Tv1hLZZoEJtrg==",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
+          "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
+          "requires": {}
+        },
+        "typescript": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+          "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
           "peer": true
         }
       }
     },
-    "contentful-sdk-core": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.10.4.tgz",
-      "integrity": "sha512-vnivU13pKqFzs/eEugqOaDkKce6ZljBkpp6l25MsG8LA1HPCQNBnIkqP5VUbwk/ub7tkHteV9HtoTnmpdvB+Zg==",
-      "peer": true,
+    "contentful-management": {
+      "version": "10.35.3",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-10.35.3.tgz",
+      "integrity": "sha512-kX/dIfIChAViTkjYZdTzj2Yf3PF7G1kXgLf44qwaE9rwv2tZ5/MjYrqZhDCDxaSBREhD9NZWpsXWPGDD5I2CLw==",
       "requires": {
-        "fast-copy": "^2.1.0",
+        "@contentful/rich-text-types": "^16.0.3",
+        "@types/json-patch": "0.0.30",
+        "axios": "^0.27.1",
+        "contentful-sdk-core": "^7.0.1",
+        "fast-copy": "^3.0.0",
+        "lodash.isplainobject": "^4.0.6",
+        "type-fest": "^3.0.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "type-fest": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.10.0.tgz",
+          "integrity": "sha512-hmAPf1datm+gt3c2mvu0sJyhFy6lTkIGf0GzyaZWxRLnabQfPUqg6tF95RPg6sLxKI7nFLGdFxBcf2/7+GXI+A==",
+          "requires": {}
+        },
+        "typescript": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+          "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+          "peer": true
+        }
+      }
+    },
+    "contentful-resolve-response": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.7.0.tgz",
+      "integrity": "sha512-NIaQkXAdNWf/1wp13aqtrmHWHy71oCIIbynojGs9ONDtA7hBXC2yCEf2IjzfgOkrkEfOMvwDQHizD0WmL6FR8w==",
+      "requires": {
+        "fast-copy": "^2.1.7"
+      },
+      "dependencies": {
+        "fast-copy": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+          "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+        }
+      }
+    },
+    "contentful-sdk-core": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.1.0.tgz",
+      "integrity": "sha512-RzTPnRsbCdVAhyka3wa9sDsAu9YsxoerNgaMqd63Ljb7qpG2zkdHcP7NTfyIbuHDJNJdAQdifyafxfEEwP+q/w==",
+      "requires": {
+        "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
         "p-throttle": "^4.1.1",
         "qs": "^6.9.4"
+      },
+      "dependencies": {
+        "fast-copy": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+          "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+        }
       }
     },
     "contentful-ui-extensions-sdk": {
@@ -26255,6 +28477,19 @@
         "whatwg-url": "^8.0.0"
       }
     },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
+    },
+    "dayjs": {
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -26501,6 +28736,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
+    },
+    "detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -27812,10 +30052,9 @@
       }
     },
     "fast-copy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.1.tgz",
-      "integrity": "sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==",
-      "peer": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -28004,6 +30243,14 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "focus-lock": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.11.6.tgz",
+      "integrity": "sha512-KSuV3ur4gf2KqMNoZx3nXNVhqCkn42GuTYCX4tXPEwf0MjpFQmNMiN6m7dXaUXgIoivL6/65agoUMg4RLS0Vbg==",
+      "requires": {
+        "tslib": "^2.0.3"
       }
     },
     "follow-redirects": {
@@ -30143,6 +32390,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
     "json3": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
@@ -30302,14 +32554,12 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "peer": true
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "peer": true
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -31209,8 +33459,7 @@
     "p-throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
-      "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
-      "peer": true
+      "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g=="
     },
     "p-try": {
       "version": "2.2.0",
@@ -32889,6 +35138,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "react-fast-compare": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.1.tgz",
+      "integrity": "sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg=="
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -33191,9 +35445,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -35385,9 +37639,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2378,21 +2378,6 @@
         "react": ">=16.8"
       }
     },
-    "node_modules/@contentful/f36-components/node_modules/@contentful/f36-icons": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
-      "dependencies": {
-        "@contentful/f36-core": "^4.23.2",
-        "@contentful/f36-icon": "^4.23.2",
-        "@contentful/f36-tokens": "^4.0.1",
-        "emotion": "^10.0.17"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
     "node_modules/@contentful/f36-components/node_modules/@contentful/f36-list": {
       "version": "4.40.0",
       "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.40.0.tgz",
@@ -2960,6 +2945,71 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/@contentful/f36-icons": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
+      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.23.2",
+        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-icons/node_modules/@contentful/f36-core": {
+      "version": "4.40.6",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.40.6.tgz",
+      "integrity": "sha512-vEfSyU3+R6ZCtd9yXUEZ32T6MEqnuo8PSZL+VYw3RdjUzV70NE0K4y3aav21nBm3p51NCwImMG8XfjwabBQE1A==",
+      "dependencies": {
+        "@contentful/f36-tokens": "^4.0.1",
+        "@emotion/core": "^10.1.1",
+        "@emotion/is-prop-valid": "^1.2.0",
+        "csstype": "^3.1.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-icons/node_modules/@contentful/f36-core/node_modules/@emotion/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/@contentful/f36-icons/node_modules/@contentful/f36-icon": {
+      "version": "4.40.6",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.40.6.tgz",
+      "integrity": "sha512-dXfMLMC2Lxf/fcbPv1sdlowOv8kPRr0CRUqFrI/bj8Td+NUcpSXW4TFTSgqBBmQso0C/rNgF5+3Wab3Q7qOKvQ==",
+      "dependencies": {
+        "@contentful/f36-core": "^4.40.6",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@contentful/f36-icons/node_modules/csstype": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/@contentful/f36-tokens": {
       "version": "4.0.1",
@@ -23852,17 +23902,6 @@
             "emotion": "^10.0.17"
           }
         },
-        "@contentful/f36-icons": {
-          "version": "4.25.0",
-          "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
-          "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
-          "requires": {
-            "@contentful/f36-core": "^4.23.2",
-            "@contentful/f36-icon": "^4.23.2",
-            "@contentful/f36-tokens": "^4.0.1",
-            "emotion": "^10.0.17"
-          }
-        },
         "@contentful/f36-list": {
           "version": "4.40.0",
           "resolved": "https://registry.npmjs.org/@contentful/f36-list/-/f36-list-4.40.0.tgz",
@@ -24313,6 +24352,61 @@
           "requires": {
             "loose-envify": "^1.0.0"
           }
+        }
+      }
+    },
+    "@contentful/f36-icons": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@contentful/f36-icons/-/f36-icons-4.25.0.tgz",
+      "integrity": "sha512-PDEvCtoAfP3FF7K+slhOb+LP2MxlUSKQXmRUmtBPXIFz+usZC4FOGQAMWKF9kdnDEq9C/kaYiCzPkZ6BJC4hmg==",
+      "requires": {
+        "@contentful/f36-core": "^4.23.2",
+        "@contentful/f36-icon": "^4.23.2",
+        "@contentful/f36-tokens": "^4.0.1",
+        "emotion": "^10.0.17"
+      },
+      "dependencies": {
+        "@contentful/f36-core": {
+          "version": "4.40.6",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-core/-/f36-core-4.40.6.tgz",
+          "integrity": "sha512-vEfSyU3+R6ZCtd9yXUEZ32T6MEqnuo8PSZL+VYw3RdjUzV70NE0K4y3aav21nBm3p51NCwImMG8XfjwabBQE1A==",
+          "requires": {
+            "@contentful/f36-tokens": "^4.0.1",
+            "@emotion/core": "^10.1.1",
+            "@emotion/is-prop-valid": "^1.2.0",
+            "csstype": "^3.1.1",
+            "emotion": "^10.0.17"
+          },
+          "dependencies": {
+            "@emotion/core": {
+              "version": "10.3.1",
+              "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.3.1.tgz",
+              "integrity": "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==",
+              "requires": {
+                "@babel/runtime": "^7.5.5",
+                "@emotion/cache": "^10.0.27",
+                "@emotion/css": "^10.0.27",
+                "@emotion/serialize": "^0.11.15",
+                "@emotion/sheet": "0.9.4",
+                "@emotion/utils": "0.11.3"
+              }
+            }
+          }
+        },
+        "@contentful/f36-icon": {
+          "version": "4.40.6",
+          "resolved": "https://registry.npmjs.org/@contentful/f36-icon/-/f36-icon-4.40.6.tgz",
+          "integrity": "sha512-dXfMLMC2Lxf/fcbPv1sdlowOv8kPRr0CRUqFrI/bj8Td+NUcpSXW4TFTSgqBBmQso0C/rNgF5+3Wab3Q7qOKvQ==",
+          "requires": {
+            "@contentful/f36-core": "^4.40.6",
+            "@contentful/f36-tokens": "^4.0.1",
+            "emotion": "^10.0.17"
+          }
+        },
+        "csstype": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+          "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "engines": {
+    "node": ">=16.11 <17",
+    "npm": ">=7"
+  },  
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
     "contentful-management": "^10.35.3",
-    "contentful-ui-extensions-sdk": "^4.3.1",
+    "contentful-ui-extensions-sdk": "^4.17.2",
     "localforage": "^1.9.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "engines": {
     "node": ">=16.11 <17",
     "npm": ">=7"
-  },  
+  },
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "dependencies": {
+    "@contentful/f36-components": "^4.40.0",
     "@contentful/field-editor-single-line": "^0.8.4",
     "@contentful/field-editor-test-utils": "^0.6.4",
     "@contentful/forma-36-fcss": "0.0.35",
@@ -16,6 +17,7 @@
     "@types/node": "^12.12.53",
     "@types/react": "^16.9.43",
     "@types/react-dom": "^16.9.8",
+    "contentful-management": "^10.35.3",
     "contentful-ui-extensions-sdk": "^4.3.1",
     "localforage": "^1.9.0",
     "react": "^16.13.1",

--- a/src/arrowForward.svg
+++ b/src/arrowForward.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="css-j3q0cj" data-test-id="cf-ui-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M0 0h24v24H0z" fill="none"></path><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"></path></svg>

--- a/src/components/ConfigScreen.spec.tsx
+++ b/src/components/ConfigScreen.spec.tsx
@@ -1,24 +1,16 @@
 import React from 'react';
 import ConfigScreen from './ConfigScreen';
-import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen, act } from '@testing-library/react'
+import mockSdk from '../../__mocks__/sdk'
+import { ConfigAppSDK } from "contentful-ui-extensions-sdk";
+
 
 describe('Config Screen component', () => {
   it('Component text exists', async () => {
-    const mockSdk: any = {
-      app: {
-        onConfigure: jest.fn(),
-        getParameters: jest.fn().mockReturnValueOnce({}),
-        setReady: jest.fn()
-      }
-    };
-    const { getByText } = render(<ConfigScreen sdk={mockSdk} />);
+    await act(async () => {
+      render(<ConfigScreen sdk={mockSdk as unknown as ConfigAppSDK} />)
+    })
+    expect(screen.getByText('Nacelle Space Token')).toBeInTheDocument()
 
-    // simulate the user clicking the install button
-    const configurationData = await mockSdk.app.onConfigure.mock.calls[0][0]();
-
-    expect(
-      getByText('Welcome to your contentful app. This is your config page.')
-    ).toBeInTheDocument();
   });
 });

--- a/src/components/ConfigScreen.tsx
+++ b/src/components/ConfigScreen.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { AppExtensionSDK } from "contentful-ui-extensions-sdk";
+import { ConfigAppSDK } from "contentful-ui-extensions-sdk";
 import {
   Card,
   Form,
@@ -22,7 +22,7 @@ export interface AppInstallationParameters {
 }
 
 interface ConfigProps {
-  sdk: AppExtensionSDK;
+  sdk: ConfigAppSDK;
 }
 
 interface ConfigState {

--- a/src/components/Dialog.spec.tsx
+++ b/src/components/Dialog.spec.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
-import Dialog from './Dialog';
-import { render } from '@testing-library/react';
+import React from 'react'
+import Dialog from './Dialog'
+import { render, screen, act } from '@testing-library/react'
+import mockSdk from '../../__mocks__/sdk'
+import { DialogAppSDK } from 'contentful-ui-extensions-sdk'
 
 describe('Dialog component', () => {
-  it('Component text exists', () => {
-    const { getByText } = render(<Dialog />);
-
-    expect(getByText('Hello Dialog Component')).toBeInTheDocument();
-  });
-});
+  it('Component text exists', async () => {
+    await act(async () => {
+      render(<Dialog sdk={mockSdk as unknown as DialogAppSDK} />)
+    })
+    expect(screen.getByText('Search for collections')).toBeInTheDocument()
+  })
+})

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -12,7 +12,7 @@ import {
 import Paginator from './Paginator'
 import ResourceListItem from './ResourceListItem'
 import { css } from 'emotion'
-import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk'
+import { DialogAppSDK } from 'contentful-ui-extensions-sdk'
 import { AppInstallationParameters } from './ConfigScreen'
 import NacelleClient from '@nacelle/client-js-sdk'
 
@@ -23,7 +23,7 @@ const skeletonList = [...Array(5)].map((_, i) => {
 })
 
 interface DialogProps {
-  sdk: DialogExtensionSDK
+  sdk: DialogAppSDK
 }
 
 export interface Warp2Settings {
@@ -108,7 +108,7 @@ export default class Dialog extends Component<DialogProps, DialogState> {
       nacelleSpaceToken: token,
       nacelleEndpoint: endpoint
     } = this.props.sdk.parameters.installation as AppInstallationParameters
-    const invocation = this.props.sdk.parameters.invocation as DialogState
+    const invocation = this.props.sdk.parameters.invocation as unknown as DialogState
     const { value } = invocation
 
     // Set data handlers

--- a/src/components/EntryEditor.tsx
+++ b/src/components/EntryEditor.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { EditorExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { EditorAppSDK } from 'contentful-ui-extensions-sdk';
 
 interface EditorProps {
-  sdk: EditorExtensionSDK;
+  sdk: EditorAppSDK;
 }
 
 const Entry = (props: EditorProps) => {

--- a/src/components/Field.spec.tsx
+++ b/src/components/Field.spec.tsx
@@ -1,11 +1,17 @@
-import React from 'react';
-import Field from './Field';
-import { render } from '@testing-library/react';
+import React from 'react'
+import Field from './Field'
+import { render, screen, act } from '@testing-library/react'
+import mockSdk from '../../__mocks__/sdk'
+import { FieldAppSDK } from 'contentful-ui-extensions-sdk'
 
 describe('Field component', () => {
-  it('Component text exists', () => {
-    const { getByText } = render(<Field />);
-
-    expect(getByText('Hello Entry Field Component')).toBeInTheDocument();
-  });
-});
+  beforeEach(() => {
+    mockSdk.field.getValue.mockImplementation(() => 'Hello Entry Field Component')
+  })
+  it('Component text exists', async () => {
+    await act(async () => {
+      render(<Field sdk={mockSdk as unknown as FieldAppSDK} />)
+    })
+    expect(screen.getByText('Hello Entry Field Component')).toBeInTheDocument()
+  })
+})

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -1,11 +1,11 @@
 import React, { Component } from 'react'
 import { Button, Card, Icon } from '@contentful/forma-36-react-components'
-import { FieldExtensionSDK } from 'contentful-ui-extensions-sdk'
+import { FieldAppSDK, SerializedJSONValue } from 'contentful-ui-extensions-sdk'
 import { css } from 'emotion'
 import logo from '../logo-dark.svg'
 
 interface FieldProps {
-  sdk: FieldExtensionSDK
+  sdk: FieldAppSDK
 }
 
 interface FieldState {}
@@ -41,7 +41,7 @@ export default class Field extends Component<FieldProps, FieldState> {
       title: `Choose Resource`,
       minHeight: 400,
       allowHeightOverflow: true,
-      parameters,
+      parameters: parameters as unknown as SerializedJSONValue[],
     })
     if (data && data.dialogState) {
       const { dialogState } = data

--- a/src/components/NacelleReferences/Loading.tsx
+++ b/src/components/NacelleReferences/Loading.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { Spinner } from '@contentful/f36-components'
+import { css } from 'emotion'
+
+const Loading = () => {
+  return (
+    <div
+      className={css({
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginTop: '100px'
+      })}
+    >
+      <Spinner size="large" />
+    </div>
+  )
+}
+
+export default Loading

--- a/src/components/NacelleReferences/NacelleReferences.tsx
+++ b/src/components/NacelleReferences/NacelleReferences.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react'
+import { BaseExtensionSDK } from 'contentful-ui-extensions-sdk'
+import Loading from './Loading'
+import ReferenceTable, { ReferenceTableRow } from './ReferenceTable'
+import getNacelleFields from '../../utils/getNacelleFields'
+
+interface NacelleReferencesProps {
+  sdk: BaseExtensionSDK
+}
+
+const NacelleReferences = (props: NacelleReferencesProps) => {
+  const [data, setData] = useState<ReferenceTableRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const cmaAdapter = props.sdk.cmaAdapter
+    const appId = props.sdk.ids.app
+    const spaceId = props.sdk.ids.space
+    const envId = props.sdk.ids.environment
+
+    getNacelleFields(cmaAdapter, appId, spaceId, envId)
+      .then((res) => {
+        setData(res)
+        setLoading(false)
+      })
+      .catch((err) => {
+        throw new Error(err)
+      })
+  }, [props.sdk])
+
+  if (loading) {
+    return <Loading />
+  } else if (data && data.length) {
+    return <ReferenceTable data={data} />
+  } else {
+    return <p>No data found</p>
+  }
+}
+
+export default NacelleReferences

--- a/src/components/NacelleReferences/NacelleReferences.tsx
+++ b/src/components/NacelleReferences/NacelleReferences.tsx
@@ -1,31 +1,30 @@
 import React, { useEffect, useState } from 'react'
-import { BaseExtensionSDK } from 'contentful-ui-extensions-sdk'
+import { BaseAppSDK } from 'contentful-ui-extensions-sdk'
 import Loading from './Loading'
 import ReferenceTable, { ReferenceTableRow } from './ReferenceTable'
 import getNacelleFields from '../../utils/getNacelleFields'
 
 interface NacelleReferencesProps {
-  sdk: BaseExtensionSDK
+  sdk: BaseAppSDK
 }
 
 const NacelleReferences = (props: NacelleReferencesProps) => {
   const [data, setData] = useState<ReferenceTableRow[]>([])
   const [loading, setLoading] = useState(true)
 
+
   useEffect(() => {
     const cmaAdapter = props.sdk.cmaAdapter
     const appId = props.sdk.ids.app
     const spaceId = props.sdk.ids.space
     const envId = props.sdk.ids.environment
-
-    getNacelleFields(cmaAdapter, appId, spaceId, envId)
-      .then((res) => {
-        setData(res)
-        setLoading(false)
-      })
-      .catch((err) => {
-        throw new Error(err)
-      })
+      setLoading(true)
+      getNacelleFields(cmaAdapter, appId, spaceId, envId)
+        .then((res) => setData(res))
+        .catch((err) => {
+          throw new Error(err)
+        })
+        .finally(() => setLoading(false))
   }, [props.sdk])
 
   if (loading) {

--- a/src/components/NacelleReferences/NacelleReferences.tsx
+++ b/src/components/NacelleReferences/NacelleReferences.tsx
@@ -12,24 +12,23 @@ const NacelleReferences = (props: NacelleReferencesProps) => {
   const [data, setData] = useState<ReferenceTableRow[]>([])
   const [loading, setLoading] = useState(true)
 
-
   useEffect(() => {
     const cmaAdapter = props.sdk.cmaAdapter
     const appId = props.sdk.ids.app
     const spaceId = props.sdk.ids.space
     const envId = props.sdk.ids.environment
-      setLoading(true)
-      getNacelleFields(cmaAdapter, appId, spaceId, envId)
-        .then((res) => setData(res))
-        .catch((err) => {
-          throw new Error(err)
-        })
-        .finally(() => setLoading(false))
+    setLoading(true)
+    getNacelleFields(cmaAdapter, appId, spaceId, envId)
+      .then((res) => setData(res))
+      .catch((err) => {
+        throw new Error(err)
+      })
+      .finally(() => setLoading(false))
   }, [props.sdk])
 
   if (loading) {
     return <Loading />
-  } else if (data && data.length) {
+  } else if (data?.length) {
     return <ReferenceTable data={data} />
   } else {
     return <p>No data found</p>

--- a/src/components/NacelleReferences/ReferenceTable.tsx
+++ b/src/components/NacelleReferences/ReferenceTable.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react'
+import {
+  Table,
+  Popover,
+  IconButton,
+  Box,
+  Button
+} from '@contentful/f36-components'
+import { Icon } from '@contentful/forma-36-react-components'
+import { css } from 'emotion'
+
+export interface ReferenceTableRow {
+  type: string
+  field: string
+  nacelleReference: string
+  link: string
+}
+
+const ReferenceTable = (props: { data: ReferenceTableRow[] }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const row = {
+    border: '0',
+    margin: '0',
+    background: 'red'
+  }
+
+  const tableRows = props.data.map((item, index) => {
+    return (
+      <Table.Row key={index} className={css(row)}>
+        <Table.Cell>
+          <strong>{item.type}</strong>
+        </Table.Cell>
+        <Table.Cell>{item.field}</Table.Cell>
+        <Table.Cell>{item.nacelleReference}</Table.Cell>
+        <Table.Cell>
+          <Popover isOpen={isOpen} onClose={() => setIsOpen(false)}>
+            <Popover.Trigger>
+              <IconButton
+                className={css({
+                  float: 'right',
+                  marginRight: '36px'
+                })}
+                onClick={() => setIsOpen(!isOpen)}
+                variant="transparent"
+                aria-label="Select the date"
+                icon={<Icon icon="MoreHorizontal" color="muted" size="small" />}
+              />
+            </Popover.Trigger>
+            <Popover.Content>
+              <Box padding="spacingM">
+                <Button
+                  variant="secondary"
+                  as="a"
+                  href={item.link}
+                  target="_blank"
+                >
+                  Go to contentType page
+                </Button>
+              </Box>
+            </Popover.Content>
+          </Popover>
+        </Table.Cell>
+      </Table.Row>
+    )
+  })
+  return (
+    <Table
+      className={css({
+        boxShadow: '0 0 0 0'
+      })}
+    >
+      <Table.Head>
+        <Table.Row className={css(row)}>
+          <Table.Cell>Type</Table.Cell>
+          <Table.Cell>Field</Table.Cell>
+          <Table.Cell>Nacelle Reference</Table.Cell>
+          <Table.Cell>
+            <Icon
+              className={css({
+                float: 'right',
+                marginRight: '50px'
+              })}
+              icon="Settings"
+              color="muted"
+              size="medium"
+            />
+          </Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>{tableRows}</Table.Body>
+    </Table>
+  )
+}
+
+export default ReferenceTable

--- a/src/components/NacelleReferences/ReferenceTable.tsx
+++ b/src/components/NacelleReferences/ReferenceTable.tsx
@@ -48,9 +48,11 @@ const ReferenceTable = (props: { data: ReferenceTableRow[] }) => {
               />
             </Popover.Trigger>
             <Popover.Content>
-              <Box padding="spacingM">
+              <Box className={css({
+                 padding: '4px'
+                })}>
                 <Button
-                  variant="secondary"
+                  variant="transparent"
                   as="a"
                   href={item.link}
                   target="_blank"

--- a/src/components/NacelleReferences/ReferenceTable.tsx
+++ b/src/components/NacelleReferences/ReferenceTable.tsx
@@ -8,6 +8,7 @@ import {
 } from '@contentful/f36-components'
 import { Icon } from '@contentful/forma-36-react-components'
 import { css } from 'emotion'
+import arrowForward from '../../arrowForward.svg'
 
 export interface ReferenceTableRow {
   type: string
@@ -17,7 +18,7 @@ export interface ReferenceTableRow {
 }
 
 const ReferenceTable = (props: { data: ReferenceTableRow[] }) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [openIndex, setOpenIndex] = useState(-1)
 
   const row = {
     border: '0',
@@ -34,30 +35,56 @@ const ReferenceTable = (props: { data: ReferenceTableRow[] }) => {
         <Table.Cell>{item.field}</Table.Cell>
         <Table.Cell>{item.nacelleReference}</Table.Cell>
         <Table.Cell>
-          <Popover isOpen={isOpen} onClose={() => setIsOpen(false)}>
+          <Popover
+            isOpen={index === openIndex}
+            onClose={() => setOpenIndex(-1)}
+          >
             <Popover.Trigger>
               <IconButton
                 className={css({
                   float: 'right',
                   marginRight: '36px'
                 })}
-                onClick={() => setIsOpen(!isOpen)}
+                onClick={() => setOpenIndex(index)}
                 variant="transparent"
                 aria-label="Select the date"
                 icon={<Icon icon="MoreHorizontal" color="muted" size="small" />}
               />
             </Popover.Trigger>
             <Popover.Content>
-              <Box className={css({
-                 padding: '4px'
-                })}>
+              <Box
+                className={css({
+                  padding: '4px'
+                })}
+              >
                 <Button
+                  className={css({
+                    padding: '0 5px',
+                    fontWeight: 'normal',
+                    minHeight: '32px'
+                  })}
                   variant="transparent"
                   as="a"
                   href={item.link}
                   target="_blank"
                 >
-                  Go to contentType page
+                  <span
+                    className={css({
+                      display: 'flex',
+                      gap: '25px',
+                      justifyContent: 'space-around',
+                      alignItems: 'center',
+                      margin: '0',
+                      padding: '0'
+                    })}
+                  >
+                    <span>View content type</span>
+                    <img
+                      className={css({ height: '18px' })}
+                      src={arrowForward}
+                      alt="arrow forward icon"
+                    />
+                  </span>
                 </Button>
               </Box>
             </Popover.Content>

--- a/src/components/NacelleReferences/ReferenceTable.tsx
+++ b/src/components/NacelleReferences/ReferenceTable.tsx
@@ -28,7 +28,7 @@ const ReferenceTable = (props: { data: ReferenceTableRow[] }) => {
 
   const tableRows = props.data.map((item, index) => {
     return (
-      <Table.Row key={index} className={css(row)}>
+      <Table.Row key={`${item.field}::${item.type}`} className={css(row)}>
         <Table.Cell>
           <strong>{item.type}</strong>
         </Table.Cell>

--- a/src/components/Page.spec.tsx
+++ b/src/components/Page.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Page from './Page'
 import { render, screen, act } from '@testing-library/react'
-import { BaseExtensionSDK } from 'contentful-ui-extensions-sdk'
+import { BaseAppSDK } from 'contentful-ui-extensions-sdk'
 import mockSdk from '../../__mocks__/sdk'
 import mockContentTypes from '../../__mocks__/contentTypes'
 import mockEditorInterfaces from '../../__mocks__/editorInterfaces'
@@ -39,7 +39,7 @@ describe('Page component', () => {
 
   it('Component text exists', async () => {
     await act(async () => {
-      render(<Page sdk={mockSdk as unknown as BaseExtensionSDK} />)
+      render(<Page sdk={mockSdk as unknown as BaseAppSDK} />)
     })
 
     expect(screen.getByText('Nacelle Refs')).toBeInTheDocument()

--- a/src/components/Page.spec.tsx
+++ b/src/components/Page.spec.tsx
@@ -1,11 +1,47 @@
-import React from 'react';
-import Page from './Page';
-import { render } from '@testing-library/react';
+import React from 'react'
+import Page from './Page'
+import { render, screen, act } from '@testing-library/react'
+import { BaseExtensionSDK } from 'contentful-ui-extensions-sdk'
+import mockSdk from '../../__mocks__/sdk'
+import mockContentTypes from '../../__mocks__/contentTypes'
+import mockEditorInterfaces from '../../__mocks__/editorInterfaces'
+
+
+const mockGetContentType = jest.fn()
+const mockGetEditorInterfaces = jest.fn()
+
+const mockGetEnvironment = () => {
+  return {
+    getContentTypes: mockGetContentType,
+    getEditorInterfaceForContentType: mockGetEditorInterfaces
+  }
+}
+
+jest.mock('contentful-management', () => {
+  return {
+    createClient: () => {
+      return {
+        getSpace: () => {
+          return {
+            getEnvironment: mockGetEnvironment
+          }
+        }
+      }
+    }
+  }
+})
 
 describe('Page component', () => {
-  it('Component text exists', () => {
-    const { getByText } = render(<Page />);
+  beforeEach(() => {
+    mockGetContentType.mockImplementation(() => Promise.resolve(mockContentTypes))
+    mockGetEditorInterfaces.mockImplementation(() => Promise.resolve(mockEditorInterfaces))
+  })
 
-    expect(getByText('Hello Page Component')).toBeInTheDocument();
-  });
-});
+  it('Component text exists', async () => {
+    await act(async () => {
+      render(<Page sdk={mockSdk as unknown as BaseExtensionSDK} />)
+    })
+
+    expect(screen.getByText('Nacelle Refs')).toBeInTheDocument()
+  })
+})

--- a/src/components/Page.spec.tsx
+++ b/src/components/Page.spec.tsx
@@ -6,7 +6,6 @@ import mockSdk from '../../__mocks__/sdk'
 import mockContentTypes from '../../__mocks__/contentTypes'
 import mockEditorInterfaces from '../../__mocks__/editorInterfaces'
 
-
 const mockGetContentType = jest.fn()
 const mockGetEditorInterfaces = jest.fn()
 
@@ -42,6 +41,6 @@ describe('Page component', () => {
       render(<Page sdk={mockSdk as unknown as BaseAppSDK} />)
     })
 
-    expect(screen.getByText('Nacelle Refs')).toBeInTheDocument()
+    expect(screen.getByText('Nacelle References')).toBeInTheDocument()
   })
 })

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react'
 import { Button, Workbench } from '@contentful/forma-36-react-components'
-import { PageExtensionSDK } from 'contentful-ui-extensions-sdk'
+import { BaseAppSDK } from 'contentful-ui-extensions-sdk'
 import NacelleReferences from './NacelleReferences/NacelleReferences'
 
 interface PageProps {
-  sdk: PageExtensionSDK
+  sdk: BaseAppSDK
 }
 
 interface PageState {}

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,16 +1,16 @@
-import React, { Component } from 'react';
-import { Button, Card, Icon,  Paragraph,  Workbench } from '@contentful/forma-36-react-components';
-import { PageExtensionSDK } from 'contentful-ui-extensions-sdk';
+import React, { Component } from 'react'
+import { Button, Workbench } from '@contentful/forma-36-react-components'
+import { PageExtensionSDK } from 'contentful-ui-extensions-sdk'
+import NacelleReferences from './NacelleReferences/NacelleReferences'
 
 interface PageProps {
-  sdk: PageExtensionSDK;
+  sdk: PageExtensionSDK
 }
 
 interface PageState {}
 
 class Page extends Component<PageProps, PageState> {
-  state = {
-  }
+  state = {}
 
   constructor(props: PageProps) {
     super(props)
@@ -20,29 +20,22 @@ class Page extends Component<PageProps, PageState> {
 
   async componentDidMount() {
     console.log('sdk', this.props.sdk)
-    // Get Space Data
   }
 
   render() {
     return (
-      <Workbench
-      >
-      <Workbench.Header
-        title={'Nacelle'}
-        description="Lorem Ipsum dolor sit amet."
-        icon={<Icon icon="ArrowDown" />}
-        actions={<Button buttonType="muted">Click</Button>}
-      />
-      <Workbench.Content>
-        <Card>
-          <Paragraph>
-            Hello Page Component
-          </Paragraph>
-        </Card>
-      </Workbench.Content>
-    </Workbench>
+      <Workbench>
+        <Workbench.Header
+          title={'Nacelle Refs'}
+          description="fields that reference outside entities, such as commerce data."
+          actions={<Button buttonType="muted">New Reference</Button>}
+        />
+        <Workbench.Content className="workbench">
+          <NacelleReferences sdk={this.props.sdk} />
+        </Workbench.Content>
+      </Workbench>
     )
   }
 }
 
-export default Page;
+export default Page

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -18,15 +18,11 @@ class Page extends Component<PageProps, PageState> {
     this.state = {}
   }
 
-  async componentDidMount() {
-    console.log('sdk', this.props.sdk)
-  }
-
   render() {
     return (
       <Workbench>
         <Workbench.Header
-          title={'Nacelle Refs'}
+          title={'Nacelle References'}
           description="fields that reference outside entities, such as commerce data."
           actions={<Button buttonType="muted">New Reference</Button>}
         />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { SidebarExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { SidebarAppSDK } from 'contentful-ui-extensions-sdk';
 
 interface SidebarProps {
-  sdk: SidebarExtensionSDK;
+  sdk: SidebarAppSDK;
 }
 
 const Sidebar = (props: SidebarProps) => {

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,7 @@ div {
   font: inherit;
   vertical-align: baseline;
 }
+
+.workbench > div {
+  max-width: none;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { render } from 'react-dom';
 
 import {
-  AppExtensionSDK,
-  FieldExtensionSDK,
-  SidebarExtensionSDK,
-  DialogExtensionSDK,
-  EditorExtensionSDK,
-  PageExtensionSDK,
-  BaseExtensionSDK,
+  ConfigAppSDK,
+  FieldAppSDK,
+  SidebarAppSDK,
+  DialogAppSDK,
+  EditorAppSDK,
+  PageAppSDK,
+  BaseAppSDK,
   init,
   locations
 } from 'contentful-ui-extensions-sdk';
@@ -23,28 +23,29 @@ import Sidebar from './components/Sidebar';
 import Field from './components/Field';
 import Dialog from './components/Dialog';
 
-init((sdk: BaseExtensionSDK) => {
+init((sdk: BaseAppSDK) => {
+
   const root = document.getElementById('root');
 
   // All possible locations for your app
   // Feel free to remove unused locations
   // Dont forget to delete the file too :)
   const ComponentLocationSettings = [
-    { location: locations.LOCATION_APP_CONFIG, component: <Config sdk={sdk as AppExtensionSDK} /> },
+    { location: locations.LOCATION_APP_CONFIG, component: <Config sdk={sdk as ConfigAppSDK} /> },
     {
       location: locations.LOCATION_ENTRY_FIELD,
-      component: <Field sdk={sdk as FieldExtensionSDK} />
+      component: <Field sdk={sdk as FieldAppSDK} />
     },
     {
       location: locations.LOCATION_ENTRY_EDITOR,
-      component: <EntryEditor sdk={sdk as EditorExtensionSDK} />
+      component: <EntryEditor sdk={sdk as EditorAppSDK} />
     },
-    { location: locations.LOCATION_DIALOG, component: <Dialog sdk={sdk as DialogExtensionSDK} /> },
+    { location: locations.LOCATION_DIALOG, component: <Dialog sdk={sdk as DialogAppSDK} /> },
     {
       location: locations.LOCATION_ENTRY_SIDEBAR,
-      component: <Sidebar sdk={sdk as SidebarExtensionSDK} />
+      component: <Sidebar sdk={sdk as SidebarAppSDK} />
     },
-    { location: locations.LOCATION_PAGE, component: <Page sdk={sdk as PageExtensionSDK} /> }
+    { location: locations.LOCATION_PAGE, component: <Page sdk={sdk as PageAppSDK} /> }
   ];
 
   // Select a component depending on a location in which the app is rendered.

--- a/src/utils/getNacelleFields.spec.ts
+++ b/src/utils/getNacelleFields.spec.ts
@@ -37,6 +37,7 @@ describe('`getnacelleFields`', () => {
       Promise.resolve(mockEditorInterfaces)
     )
   })
+
   it('should return an array of `ReferenceTableRow` objects', async () => {
     const referenceTableRows: ReferenceTableRow[] = await getNacelleFields(
       mockSdk.cmaAdapter,

--- a/src/utils/getNacelleFields.spec.ts
+++ b/src/utils/getNacelleFields.spec.ts
@@ -1,0 +1,65 @@
+import mockSdk from '../../__mocks__/sdk'
+import mockContentTypes from '../../__mocks__/contentTypes'
+import mockEditorInterfaces from '../../__mocks__/editorInterfaces'
+import { ReferenceTableRow } from '../components/NacelleReferences/ReferenceTable'
+import getNacelleFields from './getNacelleFields'
+
+const mockGetContentType = jest.fn()
+const mockGetEditorInterfaces = jest.fn()
+
+const mockGetEnvironment = () => {
+  return {
+    getContentTypes: mockGetContentType,
+    getEditorInterfaceForContentType: mockGetEditorInterfaces
+  }
+}
+
+jest.mock('contentful-management', () => {
+  return {
+    createClient: () => {
+      return {
+        getSpace: () => {
+          return {
+            getEnvironment: mockGetEnvironment
+          }
+        }
+      }
+    }
+  }
+})
+
+describe('`getnacelleFields`', () => {
+  beforeEach(() => {
+    mockGetContentType.mockImplementation(() =>
+      Promise.resolve(mockContentTypes)
+    )
+    mockGetEditorInterfaces.mockImplementation(() =>
+      Promise.resolve(mockEditorInterfaces)
+    )
+  })
+  it('should return an array of `ReferenceTableRow` objects', async () => {
+    const referenceTableRows: ReferenceTableRow[] = await getNacelleFields(
+      mockSdk.cmaAdapter,
+      mockSdk.ids.app,
+      mockSdk.ids.space,
+      mockSdk.ids.environment
+    )
+
+    const expectedTableRows = [
+      {
+        field: 'collectionHandle',
+        link: `https://app.contentful.com/spaces/${mockSdk.ids.space}/environments/${mockSdk.ids.environment}/content_types/collectionGrid/fields`,
+        nacelleReference: 'N/A (*Collection Handle as string)',
+        type: 'collectionGrid'
+      },
+      {
+        field: 'product',
+        link: `https://app.contentful.com/spaces/${mockSdk.ids.space}/environments/${mockSdk.ids.environment}/content_types/collectionGrid/fields`,
+        nacelleReference: 'PRODUCT',
+        type: 'collectionGrid'
+      }
+    ]
+
+    expect(referenceTableRows).toEqual(expectedTableRows)
+  })
+})

--- a/src/utils/getNacelleFields.ts
+++ b/src/utils/getNacelleFields.ts
@@ -1,9 +1,9 @@
 import { createClient } from 'contentful-management'
 import { ReferenceTableRow } from '../components/NacelleReferences/ReferenceTable'
-import { BaseExtensionSDK } from 'contentful-ui-extensions-sdk'
+import { BaseAppSDK } from 'contentful-ui-extensions-sdk'
 
 const getNacelleFields = async (
-  cmaAdapter: BaseExtensionSDK['cmaAdapter'],
+  cmaAdapter: BaseAppSDK['cmaAdapter'],
   appId: string | undefined,
   spaceId: string,
   envId: string

--- a/src/utils/getNacelleFields.ts
+++ b/src/utils/getNacelleFields.ts
@@ -1,0 +1,70 @@
+import { createClient } from 'contentful-management'
+import { ReferenceTableRow } from '../components/NacelleReferences/ReferenceTable'
+import { BaseExtensionSDK } from 'contentful-ui-extensions-sdk'
+
+const getNacelleFields = async (
+  cmaAdapter: BaseExtensionSDK['cmaAdapter'],
+  appId: string | undefined,
+  spaceId: string,
+  envId: string
+) => {
+  const dataArray: ReferenceTableRow[] = []
+
+  const cma = createClient({ apiAdapter: cmaAdapter })
+  const space = await cma.getSpace(spaceId)
+  const environment = await space.getEnvironment(envId)
+  const contentTypes = await environment.getContentTypes()
+
+  const typesWithWidgets = await Promise.all(
+    contentTypes.items.map(async (contentType) => {
+      const { controls } = await environment.getEditorInterfaceForContentType(
+        contentType.sys.id
+      )
+      return {
+        contentType,
+        controls
+      }
+    })
+  )
+
+  typesWithWidgets.forEach((typeWithWidget) => {
+    const { controls, contentType } = typeWithWidget
+    if (controls) {
+      const references = controls.filter(
+        (control) => control.widgetId === appId
+      )
+      if (references) {
+        references.forEach((reference) => {
+          const field = contentType.fields.find(
+            (field) => field.id === reference.fieldId
+          )
+          const hiddenField = contentType.fields.find(
+            (field) => field.id === 'nclRefMap'
+          )
+
+          let nacelleReference = ''
+
+          if (field?.type === 'JSON' && hiddenField?.validations) {
+            nacelleReference =
+              hiddenField.validations[0].linkContentType
+                ?.find((type) => type.includes(field.id))
+                ?.replace(`${field.id}:`, '') ?? ''
+          } else {
+            nacelleReference = `N/A (*${field?.name} as string)`
+          }
+
+          dataArray.push({
+            type: contentType.sys.id,
+            field: reference.fieldId,
+            nacelleReference,
+            link: `https://app.contentful.com/spaces/${spaceId}/environments/${envId}/content_types/${contentType.sys.id}/fields`
+          })
+        })
+      }
+    }
+  })
+
+  return dataArray
+}
+
+export default getNacelleFields


### PR DESCRIPTION
## Why are these changes introduced?

Addresses [ENG-9415](https://nacelle.atlassian.net/browse/ENG-9415) <!-- link to Jira ticket if one exists -->

## What is this pull request doing?

- Adds a Nacelle Reference page to the Nacelle app
- Uses [CMA](https://www.contentful.com/developers/docs/references/content-management-api/) to fetch `contentTypes` and `EditorInterfaces`
- Adds test to ensure the table contains the appropriate data

## How to test

- `npm i && npm run test` -> all tests should pass
- Shape of the [`expected data`](https://github.com/getnacelle/contentful-app-nacelle/pull/19/files#diff-a51acca2034afc132e862e3118c9f5df56f60305983f908da14ba423dafe8c05R48) is in line with ADR075 

- `npm run start`
  - Should open a browser tab
  - Select `Prairie Wind Apparel` space
  - Select `Staging` environment
  - Click on the `Apps` menu and select `Nacelle [Local Dev]`


## Checklist

- [x] You can follow your own "How to Test" instructions and get the expected result.
- [ ] Updated the `README.md` with documentation changes (if applicable).


[ENG-9415]: https://nacelle.atlassian.net/browse/ENG-9415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ